### PR TITLE
Skim development

### DIFF
--- a/CommonCode/include/Messenger.h
+++ b/CommonCode/include/Messenger.h
@@ -727,7 +727,9 @@ public:
    float VX, VY, VZ, VXError, VYError, VZError;
    int isL1ZDCOr;
    int isL1ZDCXORJet8;
-   int gammaN, Ngamma;
+   //int gammaN, Ngamma;
+   std::vector<bool>  *gammaN;
+   std::vector<bool>  *Ngamma;
    std::vector<float> *Dpt;
    std::vector<float> *Dphi;
    std::vector<float> *Dy;
@@ -741,7 +743,7 @@ public:
    std::vector<float> *DsvpvDisErr_2D;
    std::vector<float> *Dalpha;
    std::vector<float> *Ddtheta;
-   std::vector<int> *Dgen;
+   std::vector<int>   *Dgen;
    int nTrackInAcceptanceHP;
 
    //MC only quantities

--- a/CommonCode/source/Messenger.cpp
+++ b/CommonCode/source/Messenger.cpp
@@ -2725,6 +2725,8 @@ DzeroUPCTreeMessenger::~DzeroUPCTreeMessenger()
 {
    if(Initialized == true && WriteMode == true)
    {
+      delete gammaN;
+      delete Ngamma;
       delete Dpt;
       delete Dy;
       delete Dmass;
@@ -2759,6 +2761,8 @@ bool DzeroUPCTreeMessenger::Initialize(bool Debug)
       return false;
 
    Initialized = true;
+   Ngamma = nullptr;
+   gammaN = nullptr;
    Dpt = nullptr;
    Dy = nullptr;
    Dmass = nullptr;
@@ -2864,6 +2868,8 @@ bool DzeroUPCTreeMessenger::SetBranch(TTree *T)
    Initialized = true;
    WriteMode = true;
 
+   gammaN = new std::vector<bool>();
+   Ngamma = new std::vector<bool>();
    Dpt = new std::vector<float>();
    Dy = new std::vector<float>();
    Dmass = new std::vector<float>();
@@ -2895,8 +2901,8 @@ bool DzeroUPCTreeMessenger::SetBranch(TTree *T)
    Tree->Branch("VXError",               &VXError, "VXError/F");
    Tree->Branch("VYError",               &VYError, "VYError/F");
    Tree->Branch("VZError",               &VZError, "VZError/F");
-   Tree->Branch("gammaN",                &gammaN, "gammaN/I");
-   Tree->Branch("Ngamma",                &Ngamma, "Ngamma/I");
+   Tree->Branch("gammaN",                &gammaN);
+   Tree->Branch("Ngamma",                &Ngamma);
    Tree->Branch("isL1ZDCOr",             &isL1ZDCOr, "isL1ZDCOr/I");
    Tree->Branch("isL1ZDCXORJet8",        &isL1ZDCXORJet8, "isL1ZDCXORJet8/I");
    Tree->Branch("nTrackInAcceptanceHP",  &nTrackInAcceptanceHP, "nTrackInAcceptanceHP/I");
@@ -2934,12 +2940,12 @@ void DzeroUPCTreeMessenger::Clear()
    VXError = 0;
    VYError = 0;
    VZError = 0;
-   gammaN = 0;
-   Ngamma = 0;
    isL1ZDCOr = 0;
    isL1ZDCXORJet8 = 0;
    nTrackInAcceptanceHP = 0;
 
+   gammaN->clear();
+   Ngamma->clear();
    Dpt->clear();
    Dy->clear();
    Dmass->clear();
@@ -2972,12 +2978,12 @@ void DzeroUPCTreeMessenger::CopyNonTrack(DzeroUPCTreeMessenger &M)
    VXError        = M.VXError;
    VYError        = M.VYError;
    VZError        = M.VZError;
-   gammaN         = M.gammaN;
-   Ngamma         = M.Ngamma;
    isL1ZDCOr      = M.isL1ZDCOr;
    isL1ZDCXORJet8 = M.isL1ZDCXORJet8;
    nTrackInAcceptanceHP = M.nTrackInAcceptanceHP;
 
+   if (gammaN != nullptr && M.gammaN != nullptr) *gammaN = *(M.gammaN);
+   if (Ngamma != nullptr && M.Ngamma != nullptr) *Ngamma = *(M.Ngamma);
    if(Dpt != nullptr && M.Dpt != nullptr)   *Dpt = *(M.Dpt);
    if(Dy != nullptr && M.Dy != nullptr)   *Dy = *(M.Dy);
    if(Dmass != nullptr && M.Dmass != nullptr)   *Dmass = *(M.Dmass);

--- a/SampleGeneration/20241027_ForestReducer_DzeroUPC/ReduceForest.cpp
+++ b/SampleGeneration/20241027_ForestReducer_DzeroUPC/ReduceForest.cpp
@@ -147,14 +147,23 @@ int main(int argc, char *argv[]) {
         MDzeroUPC.isL1ZDCXORJet8 = isL1ZDCXORJet8;
         bool ZDCgammaN = (MZDC.sumMinus > 1100. && MZDC.sumPlus < 1100.);
         bool ZDCNgamma = (MZDC.sumMinus < 1100. && MZDC.sumPlus > 1100.);
-        bool gapgammaN = GetMaxEnergyHF(&MPF, 3., 5.2) < 9.2;
-        bool gapNgamma = GetMaxEnergyHF(&MPF, -5.2, -3.) < 8.6;
-        bool gammaN_ = ZDCgammaN && gapgammaN;
-        bool Ngamma_ = ZDCNgamma && gapNgamma;
-
-        if (gammaN_ == false && Ngamma_ == false) continue;
-        MDzeroUPC.gammaN = gammaN_;
-        MDzeroUPC.Ngamma = Ngamma_;
+	
+	// Loop through the specified ranges for gapgammaN and gapNgamma
+	// gammaN[4] and Ngamma[4] are nominal selection criteria
+	bool globalDecision=false;
+	for (double gapgammaN_threshold = 5.2; gapgammaN_threshold <= 13.2; gapgammaN_threshold += 1.0) {
+            bool gapgammaN = GetMaxEnergyHF(&MPF, 3.0, 5.2) < gapgammaN_threshold;
+            bool gammaN_ = ZDCgammaN && gapgammaN;
+            MDzeroUPC.gammaN->push_back(gammaN_);
+	    if (gammaN_) globalDecision = true;
+        }
+        for (double gapNgamma_threshold = 4.6; gapNgamma_threshold <= 12.6; gapNgamma_threshold += 1.0) {
+            bool gapNgamma = GetMaxEnergyHF(&MPF, -5.2, -3.0) < gapNgamma_threshold;
+            bool Ngamma_ = ZDCNgamma && gapNgamma;
+            MDzeroUPC.Ngamma->push_back(Ngamma_);
+            if (Ngamma_) globalDecision = true;
+        }
+	if (globalDecision==false) continue;
       } // end of if (IsData == true)
 
       int nTrackInAcceptanceHP = 0;

--- a/SampleGeneration/20241027_ForestReducer_DzeroUPC/ReduceForest.cpp
+++ b/SampleGeneration/20241027_ForestReducer_DzeroUPC/ReduceForest.cpp
@@ -34,19 +34,16 @@ int main(int argc, char *argv[]) {
   string OutputFileName = CL.Get("Output");
 
   // bool DoGenLevel                    = CL.GetBool("DoGenLevel", true);
-  int Year = CL.GetInt("Year", 2023);
-  double MinDzeroPT = CL.GetDouble("MinDzeroPT", 0.);
-  double MinTrackPT = CL.GetDouble("MinTrackPT", 1);
-  double Fraction = CL.GetDouble("Fraction", 1.00);
-  bool IsData = CL.GetBool("IsData", false);
-  string PFTreeName = "particleFlowAnalyser/pftree";
-  PFTreeName = CL.Get("PFTree", PFTreeName);
-  string DGenTreeName = "Dfinder/ntGen";
-  DGenTreeName = CL.Get("DGenTree", DGenTreeName);
+  bool   IsData        = CL.GetBool  ("IsData",     false); 
+  int    Year          = CL.GetInt   ("Year",       2023);
+  double MinDzeroPT    = CL.GetDouble("MinDzeroPT", 0.); 
+  double MinTrackPT    = CL.GetDouble("MinTrackPT", 1);
+  double Fraction      = CL.GetDouble("Fraction",   1.00);
+  string PFTreeName    = CL.Get      ("PFTree",     "particleFlowAnalyser/pftree");
+  string DGenTreeName  = CL.Get      ("DGenTree",   "Dfinder/ntGen");
 
   TFile OutputFile(OutputFileName.c_str(), "RECREATE");
-  TTree Tree("Tree",
-             Form("Tree for UPC Dzero analysis (%s)", VersionString.c_str()));
+  TTree Tree("Tree", Form("Tree for UPC Dzero analysis (%s)", VersionString.c_str()));
   TTree InfoTree("InfoTree", "Information");
 
   DzeroUPCTreeMessenger MDzeroUPC;
@@ -87,8 +84,7 @@ int main(int argc, char *argv[]) {
       MSkim.GetEntry(iE);
       MTrigger.GetEntry(iE);
       MDzero.GetEntry(iE);
-      if (IsData == false)
-	MDzeroGen.GetEntry(iE);
+      if (IsData == false) MDzeroGen.GetEntry(iE);
       MZDC.GetEntry(iE);
       MDzeroUPC.Clear();
       MFilter.GetEntry(iE);
@@ -108,9 +104,7 @@ int main(int argc, char *argv[]) {
       int BestVertex = -1;
 
       for (int i = 0; i < MTrackPbPbUPC.nVtx; i++) {
-        if (BestVertex < 0 || MTrackPbPbUPC.ptSumVtx->at(i) >
-                                  MTrackPbPbUPC.ptSumVtx->at(BestVertex))
-          BestVertex = i;
+        if (BestVertex < 0 || MTrackPbPbUPC.ptSumVtx->at(i) > MTrackPbPbUPC.ptSumVtx->at(BestVertex)) BestVertex = i;
       }
       if (BestVertex >= 0) {
         MDzeroUPC.VX = MTrackPbPbUPC.xVtx->at(BestVertex);
@@ -137,60 +131,43 @@ int main(int argc, char *argv[]) {
         int pprimaryVertexFilter = MSkim.PVFilter;
         int pclusterCompatibilityFilter = MSkim.ClusterCompatibilityFilter;
         int cscTightHalo2015Filter = MFilter.cscTightHalo2015Filter;
-        if (pprimaryVertexFilter == 0 || pclusterCompatibilityFilter == 0 ||
-            cscTightHalo2015Filter == false) {
-          continue;
-        }
-        if (fabs(MTrackPbPbUPC.zVtx->at(0)) > 15) {
-          continue;
-        }
+        if (pprimaryVertexFilter == 0 || pclusterCompatibilityFilter == 0 || cscTightHalo2015Filter == false) continue;
+        if (fabs(MTrackPbPbUPC.zVtx->at(0)) > 15) continue;
+
         //  FIXME: need to be replaced with the actual PbPb triggers
-        int HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000_2023 =
-	    MTrigger.CheckTriggerStartWith("HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000");
-        int HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000_2023 =
-            MTrigger.CheckTriggerStartWith("HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000");
-        int HLT_HIUPC_ZDC1nOR_SinglePixelTrackLowPt_MaxPixelCluster400_2023 =
-            MTrigger.CheckTriggerStartWith("HLT_HIUPC_ZDC1nOR_SinglePixelTrackLowPt_MaxPixelCluster400");
-        int HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000_2023 =
-            MTrigger.CheckTriggerStartWith("HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000");
-        int isL1ZDCOr = HLT_HIUPC_ZDC1nOR_SinglePixelTrackLowPt_MaxPixelCluster400_2023 ||
-                        HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000_2023;
-        int isL1ZDCXORJet8 = HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000_2023 ||
-			     HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000_2023;
-        if (isL1ZDCOr == 0 && isL1ZDCXORJet8 == 0)
-          continue;
+        int HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000_2023         = MTrigger.CheckTriggerStartWith("HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000");
+        int HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000_2023     = MTrigger.CheckTriggerStartWith("HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000");
+        int HLT_HIUPC_ZDC1nOR_SinglePixelTrackLowPt_MaxPixelCluster400_2023 = MTrigger.CheckTriggerStartWith("HLT_HIUPC_ZDC1nOR_SinglePixelTrackLowPt_MaxPixelCluster400");
+        int HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000_2023  = MTrigger.CheckTriggerStartWith("HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000");
+        int isL1ZDCOr = HLT_HIUPC_ZDC1nOR_SinglePixelTrackLowPt_MaxPixelCluster400_2023 || HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000_2023;
+        int isL1ZDCXORJet8 = HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000_2023 || HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000_2023;
+        if (isL1ZDCOr == 0 && isL1ZDCXORJet8 == 0) continue;
 
         MDzeroUPC.isL1ZDCOr = isL1ZDCOr;
         MDzeroUPC.isL1ZDCXORJet8 = isL1ZDCXORJet8;
         bool ZDCgammaN = (MZDC.sumMinus > 1100. && MZDC.sumPlus < 1100.);
         bool ZDCNgamma = (MZDC.sumMinus < 1100. && MZDC.sumPlus > 1100.);
-
         bool gapgammaN = GetMaxEnergyHF(&MPF, 3., 5.2) < 9.2;
         bool gapNgamma = GetMaxEnergyHF(&MPF, -5.2, -3.) < 8.6;
         bool gammaN_ = ZDCgammaN && gapgammaN;
         bool Ngamma_ = ZDCNgamma && gapNgamma;
 
-        if (gammaN_ == false && Ngamma_ == false) {
-          continue;
-        }
+        if (gammaN_ == false && Ngamma_ == false) continue;
         MDzeroUPC.gammaN = gammaN_;
         MDzeroUPC.Ngamma = Ngamma_;
       } // end of if (IsData == true)
 
       int nTrackInAcceptanceHP = 0;
       for (int iTrack = 0; iTrack < MTrackPbPbUPC.nTrk; iTrack++) {
-        if (MTrackPbPbUPC.trkPt->at(iTrack) > 0.5 &&
-            fabs(MTrackPbPbUPC.trkEta->at(iTrack)) < 2.4 &&
-            MTrackPbPbUPC.highPurity->at(iTrack) == true) {
-          nTrackInAcceptanceHP++;
-        }
+        if (MTrackPbPbUPC.trkPt->at(iTrack) <= 0.5) continue; 
+	if (fabs(MTrackPbPbUPC.trkEta->at(iTrack)) >= 2.4) continue;
+        if (MTrackPbPbUPC.highPurity->at(iTrack) == false) continue;
+        nTrackInAcceptanceHP++;
       }
       MDzeroUPC.nTrackInAcceptanceHP = nTrackInAcceptanceHP;
 
       for (int iD = 0; iD < MDzero.Dsize; iD++) {
-        if (MDzero.Dpt[iD] < MinDzeroPT ||
-            MDzero.PassUPCDzero2023Cut(iD) == false)
-          continue;
+        if (MDzero.Dpt[iD] < MinDzeroPT || MDzero.PassUPCDzero2023Cut(iD) == false) continue;
         MDzeroUPC.Dpt->push_back(MDzero.Dpt[iD]);
         MDzeroUPC.Dy->push_back(MDzero.Dy[iD]);
         MDzeroUPC.Dmass->push_back(MDzero.Dmass[iD]);
@@ -203,9 +180,7 @@ int main(int argc, char *argv[]) {
         MDzeroUPC.DsvpvDisErr_2D->push_back(MDzero.DsvpvDisErr_2D[iD]);
         MDzeroUPC.Dalpha->push_back(MDzero.Dalpha[iD]);
         MDzeroUPC.Ddtheta->push_back(MDzero.Ddtheta[iD]);
-        if (IsData == false) {
-	  MDzeroUPC.Dgen->push_back(MDzero.Dgen[iD]);
-	}
+        if (IsData == false) MDzeroUPC.Dgen->push_back(MDzero.Dgen[iD]);
       }
 
       MDzeroUPC.FillEntry();
@@ -227,19 +202,17 @@ int main(int argc, char *argv[]) {
   return 0;
 }
 
-double GetMaxEnergyHF(PFTreeMessenger *M, double etaMin = 3.,
-                      double etaMax = 5.) {
-  if (M == nullptr)
-    return -1;
-  if (M->Tree == nullptr)
-    return -1;
+// ============================================================================ //
+// Function to Retrieve Maximum Energy in HF Region within Specified Eta Range
+// ============================================================================ //
+double GetMaxEnergyHF(PFTreeMessenger *M, double etaMin = 3., double etaMax = 5.) {
+  if (M == nullptr)        return -1;
+  if (M->Tree == nullptr)  return -1;
 
   double EMax = 0;
   for (int iPF = 0; iPF < M->ID->size(); iPF++) {
-    if ((M->ID->at(iPF) == 6 || M->ID->at(iPF) == 7) &&
-        M->Eta->at(iPF) > etaMin && M->Eta->at(iPF) < etaMax) {
-      if (M->E->at(iPF) > EMax)
-        EMax = M->E->at(iPF);
+    if ((M->ID->at(iPF) == 6 || M->ID->at(iPF) == 7) && M->Eta->at(iPF) > etaMin && M->Eta->at(iPF) < etaMax) {
+      if (M->E->at(iPF) > EMax) EMax = M->E->at(iPF);
     }
   }
   return EMax;


### PR DESCRIPTION
Updated gammaN and Ngamma from int to vector<bool>, with the nominal selection criteria now stored at gammaN[4] and Ngamma[4]. The variation was applied in 1 GeV intervals. Changes have been implemented in both the Messenger and UPCD Skim codes.