### PR TITLE
Dmeson cut

### DIFF
--- a/CommonCode/include/Messenger.h
+++ b/CommonCode/include/Messenger.h
@@ -730,6 +730,7 @@ public:
    //int gammaN, Ngamma;
    std::vector<bool>  *gammaN;
    std::vector<bool>  *Ngamma;
+   std::vector<bool>  *DpassCut;
    std::vector<float> *Dpt;
    std::vector<float> *Dphi;
    std::vector<float> *Dy;

--- a/CommonCode/source/Messenger.cpp
+++ b/CommonCode/source/Messenger.cpp
@@ -2728,6 +2728,7 @@ DzeroUPCTreeMessenger::~DzeroUPCTreeMessenger()
       delete gammaN;
       delete Ngamma;
       delete Dpt;
+      delete DpassCut;
       delete Dy;
       delete Dmass;
       delete Dtrk1Pt;
@@ -2764,6 +2765,7 @@ bool DzeroUPCTreeMessenger::Initialize(bool Debug)
    Ngamma = nullptr;
    gammaN = nullptr;
    Dpt = nullptr;
+   DpassCut = nullptr;
    Dy = nullptr;
    Dmass = nullptr;
    Dtrk1Pt = nullptr;
@@ -2799,6 +2801,7 @@ bool DzeroUPCTreeMessenger::Initialize(bool Debug)
    Tree->SetBranchAddress("nTrackInAcceptanceHP", &nTrackInAcceptanceHP);
 
    Tree->SetBranchAddress("Dpt", &Dpt);
+   Tree->SetBranchAddress("DpassCut", &DpassCut);
    Tree->SetBranchAddress("Dy", &Dy);
    Tree->SetBranchAddress("Dmass", &Dmass);
    Tree->SetBranchAddress("Dtrk1Pt", &Dtrk1Pt);
@@ -2871,6 +2874,7 @@ bool DzeroUPCTreeMessenger::SetBranch(TTree *T)
    gammaN = new std::vector<bool>();
    Ngamma = new std::vector<bool>();
    Dpt = new std::vector<float>();
+   DpassCut = new std::vector<bool>();
    Dy = new std::vector<float>();
    Dmass = new std::vector<float>();
    Dtrk1Pt = new std::vector<float>();
@@ -2908,6 +2912,7 @@ bool DzeroUPCTreeMessenger::SetBranch(TTree *T)
    Tree->Branch("nTrackInAcceptanceHP",  &nTrackInAcceptanceHP, "nTrackInAcceptanceHP/I");
 
    Tree->Branch("Dpt",                   &Dpt);
+   Tree->Branch("DpassCut",              &DpassCut);
    Tree->Branch("Dy",                    &Dy);
    Tree->Branch("Dmass",                 &Dmass);
    Tree->Branch("Dtrk1Pt",               &Dtrk1Pt);
@@ -2947,6 +2952,7 @@ void DzeroUPCTreeMessenger::Clear()
    gammaN->clear();
    Ngamma->clear();
    Dpt->clear();
+   DpassCut->clear();
    Dy->clear();
    Dmass->clear();
    Dtrk1Pt->clear();
@@ -2985,6 +2991,7 @@ void DzeroUPCTreeMessenger::CopyNonTrack(DzeroUPCTreeMessenger &M)
    if (gammaN != nullptr && M.gammaN != nullptr) *gammaN = *(M.gammaN);
    if (Ngamma != nullptr && M.Ngamma != nullptr) *Ngamma = *(M.Ngamma);
    if(Dpt != nullptr && M.Dpt != nullptr)   *Dpt = *(M.Dpt);
+   if(DpassCut != nullptr && M.DpassCut != nullptr)   *DpassCut = *(M.DpassCut);
    if(Dy != nullptr && M.Dy != nullptr)   *Dy = *(M.Dy);
    if(Dmass != nullptr && M.Dmass != nullptr)   *Dmass = *(M.Dmass);
    if(Dtrk1Pt != nullptr && M.Dtrk1Pt != nullptr)   *Dtrk1Pt = *(M.Dtrk1Pt);

--- a/SampleGeneration/20241027_ForestReducer_DzeroUPC/ReduceForest.cpp
+++ b/SampleGeneration/20241027_ForestReducer_DzeroUPC/ReduceForest.cpp
@@ -22,6 +22,8 @@ using namespace std;
 #include "trackingEfficiency2018PbPb.h"
 #include "trackingEfficiency2023PbPb.h"
 
+#include "include/DmesonSelection.h"
+
 int main(int argc, char *argv[]);
 double GetMaxEnergyHF(PFTreeMessenger *M, double etaMin, double etaMax);
 
@@ -189,6 +191,7 @@ int main(int argc, char *argv[]) {
         MDzeroUPC.DsvpvDisErr_2D->push_back(MDzero.DsvpvDisErr_2D[iD]);
         MDzeroUPC.Dalpha->push_back(MDzero.Dalpha[iD]);
         MDzeroUPC.Ddtheta->push_back(MDzero.Ddtheta[iD]);
+	MDzeroUPC.DpassCut->push_back(DmesonSelection(MDzero,iD));
         if (IsData == false) MDzeroUPC.Dgen->push_back(MDzero.Dgen[iD]);
       }
 

--- a/SampleGeneration/20241027_ForestReducer_DzeroUPC/include/DmesonSelection.h
+++ b/SampleGeneration/20241027_ForestReducer_DzeroUPC/include/DmesonSelection.h
@@ -1,0 +1,53 @@
+bool DmesonSelection(DzeroTreeMessenger& MDzero, int iD) {
+  const int nPtBinsOpt = 3;
+  const int nYBinsOpt = 4;
+
+  float Dchi2clCutValue[nPtBinsOpt][nYBinsOpt] = {
+    {0.1, 0.1, 0.1, 0.1}, {0.1, 0.1, 0.1, 0.1}, {0.1, 0.1, 0.1, 0.1}};
+  float DalphaCutValue[nPtBinsOpt][nYBinsOpt] = {
+    {0.2, 0.4, 0.4, 0.2}, {0.25, 0.35, 0.35, 0.25}, {0.25, 0.4, 0.4, 0.25}};
+  float DdthetaCutValue[nPtBinsOpt][nYBinsOpt] = {
+    {0.3, 0.5, 0.5, 0.3}, {0.3, 0.3, 0.3, 0.3}, {0.3, 0.3, 0.3, 0.3}};
+  float DsvpvSigCutValue[nPtBinsOpt][nYBinsOpt] = {
+    {2.5, 2.5, 2.5, 2.5}, {3.5, 3.5, 3.5, 3.5}, {3.5, 3.5, 3.5, 3.5}};
+
+  const int nPtBins = 3;
+  const int nYBins = 4;
+  float ptBins[nPtBins + 1] = {2, 5, 8, 12};
+  float yBins[nYBins + 1] = {-2.0, -1.0, 0.0, 1.0, 2.0};
+
+  float pt = MDzero.Dpt[iD];
+  float y = MDzero.Dy[iD];
+    
+  // Determine pt and y bin indices
+  int ptBin = -1;
+  int yBin = -1;
+  for (int i = 0; i < nPtBins; ++i) {
+    if (pt >= ptBins[i] && pt < ptBins[i + 1]) {
+      ptBin = i;
+      break;
+    }
+  }
+  for (int j = 0; j < nYBins; ++j) {
+    if (y >= yBins[j] && y < yBins[j + 1]) {
+      yBin = j;
+      break;
+    }
+  }
+
+  // Check if the pt and y bins were found
+  if (ptBin == -1 || yBin == -1) {
+    cerr << "Error! No pt bin and/or y bin found for D meson selection. "
+     << "pt = " << pt << ", y = " << y 
+     << ". Please check if the pt or y values fall within the defined bin ranges." << endl;
+    return 0;
+  }
+
+  // Apply cuts for the identified ptBin and yBin
+  bool pass = (MDzero.Dchi2cl[iD] >= Dchi2clCutValue[ptBin][yBin]) &&
+              (MDzero.Dalpha[iD] <= DalphaCutValue[ptBin][yBin]) &&
+              (MDzero.Ddtheta[iD] <= DdthetaCutValue[ptBin][yBin]) &&
+              (MDzero.DsvpvDistance[iD] / MDzero.DsvpvDisErr[iD] >= DsvpvSigCutValue[ptBin][yBin]);
+
+  return pass;
+}


### PR DESCRIPTION
New Helper Object: Introduced DmesonSelection as a helper function to evaluate D meson candidates against specific selection criteria, improving modularity and clarity.

Data Structure Update:

Added a vector<bool> DpassCut member to the DzeroUPCMessenger class, which stores the results of D meson selection checks (true for passing candidates).
The DpassCut vector is initialized, added to branches, and cleared along with other relevant data vectors to maintain consistency across the code.
Functionality Integration:

Implemented the DmesonSelection function in the ReduceForest.cpp main file. For each D meson candidate, DpassCut is populated based on whether the candidate meets the defined cuts.
Selection Criteria in DmesonSelection.h:
Cuts are defined by pt and y bins with arrays for variables such as Dchi2cl, Dalpha, Ddtheta, and DsvpvSig. These cuts help in filtering out D meson candidates based on their physical properties.