### PR TITLE
UPC Dzero skimmer and analysis update

### DIFF
--- a/MainAnalysis/20241029_DzeroUPC/DzeroUPC.cpp
+++ b/MainAnalysis/20241029_DzeroUPC/DzeroUPC.cpp
@@ -58,7 +58,7 @@ bool getCorrectedYields(DzeroUPCTreeMessenger *MDzeroUPC, TH1D *hDmass,
   unsigned long iEnd = nEntry * par.nChunk / par.nThread;
   ProgressBar Bar(cout, iEnd - iStart);
   Bar.SetStyle(1);
-  for (unsigned long i = iStart; i < iEnd; i++) {
+  for (unsigned long i = 0; i <MDzeroUPC->GetEntries() ; i++) {
     MDzeroUPC->GetEntry(i);
     if (i%1000==0) {
       Bar.Update(i - iStart);
@@ -139,7 +139,7 @@ int main(int argc, char *argv[]) {
    Parameters par(MinDzeroPT, MaxDzeroPT, MinDzeroY, MaxDzeroY, IsGammaN, TriggerChoice, IsData, scaleFactor);
    par.input         = CL.Get      ("Input",   "mergedSample.root");            // Input file
    par.output        = CL.Get      ("Output",  "output.root");                             	// Output file
-   par.nThread       = CL.GetInt   ("nThread", 20);         // The number of threads to be used for parallel processing.
+   par.nThread       = CL.GetInt   ("nThread", 1);         // The number of threads to be used for parallel processing.
    par.nChunk        = CL.GetInt   ("nChunk", 1);          // Specifies which chunk (segment) of the data to process, used in parallel processing.
    if (checkError(par)) return -1;
    std::cout << "Parameters are set" << std::endl;

--- a/MainAnalysis/20241029_DzeroUPC/DzeroUPC.cpp
+++ b/MainAnalysis/20241029_DzeroUPC/DzeroUPC.cpp
@@ -29,7 +29,6 @@ bool checkError(const Parameters &par) {
 // Check if the track pass selection criteria
 //============================================================//
 bool dzeroSelection(DzeroUPCTreeMessenger *b, Parameters par, int j) {
-  if ((*b->Dalpha)[j]>par.MaxDalpha) return false;
   return true;
 }
 
@@ -37,7 +36,14 @@ bool dzeroSelection(DzeroUPCTreeMessenger *b, Parameters par, int j) {
 // Check if the event pass eventSelection criteria
 //============================================================//
 bool eventSelection(DzeroUPCTreeMessenger *b, const Parameters &par) {
-  return 1;
+  if (par.IsData == false) return true;
+  if (b->selectedBkgFilter == false || b->selectedBkgFilter == false) return false;
+  if (par.IsGammaN && (b->ZDCgammaN && b->gapgammaN) == false) return false;
+  if (!par.IsGammaN && (b->ZDCNgamma && b->gapNgamma) == false) return false;
+  if (par.TriggerChoice == 1 && b->isL1ZDCOr == false) return false;
+  if (par.TriggerChoice == 2 && b->isL1ZDCXORJet8 == false) return false;
+  //if (b->nVtx >= 3) return false; //FIXME: this is to be removed once we move to HiVertexReco
+  return true;
 }
 
 //============================================================//
@@ -59,16 +65,16 @@ bool getCorrectedYields(DzeroUPCTreeMessenger *MDzeroUPC, TH1D *hDmass,
       Bar.Print();
     }
     // Check if the event passes the selection criteria
+    //if (1) {
     if (eventSelection(MDzeroUPC, par)) {
       for (unsigned long j = 0; j < MDzeroUPC->Dalpha->size(); j++) {
-         if (MDzeroUPC->Dpt->at(j) < par.MinDzeroPT) continue;
-         if (MDzeroUPC->Dpt->at(j) > par.MaxDzeroPT) continue;
-         if (MDzeroUPC->Dy->at(j) < par.MinDzeroY) continue;
-         if (MDzeroUPC->Dy->at(j) > par.MaxDzeroY) continue;
-         if (MDzeroUPC->Dalpha->at(j) < par.MaxDalpha) continue;
-	 if (!MDzeroUPC->DpassCut) continue;
-         hDmass->Fill((*MDzeroUPC->Dmass)[j]);
-	 nt->Fill((*MDzeroUPC->Dmass)[j]);
+        if (MDzeroUPC->Dpt->at(j) < par.MinDzeroPT) continue;
+        if (MDzeroUPC->Dpt->at(j) > par.MaxDzeroPT) continue;
+        if (MDzeroUPC->Dy->at(j) < par.MinDzeroY) continue;
+        if (MDzeroUPC->Dy->at(j) > par.MaxDzeroY) continue;
+        if (!MDzeroUPC->DpassCut) continue;
+        hDmass->Fill((*MDzeroUPC->Dmass)[j]);
+        nt->Fill((*MDzeroUPC->Dmass)[j]);
       }
     }
   }
@@ -122,26 +128,27 @@ private:
 int main(int argc, char *argv[]) {
   if (printHelpMessage(argc, argv))
     return 0;
-  std::cout << "Starting DzeroUPC analysis" << std::endl;
   CommandLine CL(argc, argv);
   float MinDzeroPT = CL.GetDouble("MinDzeroPT", 1); // Minimum Dzero transverse momentum threshold for Dzero selection.
   float MaxDzeroPT = CL.GetDouble("MaxDzeroPT", 2); // Maximum Dzero transverse momentum threshold for Dzero selection.
   float MinDzeroY = CL.GetDouble("MinDzeroY", -2); // Minimum Dzero rapidity threshold for Dzero selection.
   float MaxDzeroY = CL.GetDouble("MaxDzeroY", +2); // Maximum Dzero rapidity threshold for Dzero selection.
-  float MaxDalpha = CL.GetDouble("MaxDalpha", 0.3); // Minimum Dalpha threshold for Dzero selection.
-
-   Parameters par(MinDzeroPT, MaxDzeroPT, MinDzeroY, MaxDzeroY, MaxDalpha);
-   par.input         = CL.Get      ("Input",   "mergedSample/HISingleMuon-v5.root");            // Input file
+   bool IsGammaN = CL.GetBool("IsGammaN", true); // GammaN analysis (or NGamma)
+   int TriggerChoice = CL.GetInt("TriggerChoice", 2); // 0 = no trigger sel, 1 = isL1ZDCOr, 2 = isL1ZDCXORJet8
+   float scaleFactor = CL.GetDouble("scaleFactor", 1); // Scale factor for the number of events to be processed.
+   bool IsData = CL.GetBool("IsData", 0); // Data or MC
+   Parameters par(MinDzeroPT, MaxDzeroPT, MinDzeroY, MaxDzeroY, IsGammaN, TriggerChoice, IsData, scaleFactor);
+   par.input         = CL.Get      ("Input",   "mergedSample.root");            // Input file
    par.output        = CL.Get      ("Output",  "output.root");                             	// Output file
-   par.nThread       = CL.GetInt   ("nThread", 1);         // The number of threads to be used for parallel processing.
+   par.nThread       = CL.GetInt   ("nThread", 20);         // The number of threads to be used for parallel processing.
    par.nChunk        = CL.GetInt   ("nChunk", 1);          // Specifies which chunk (segment) of the data to process, used in parallel processing.
    if (checkError(par)) return -1;
-   std::cout << "Parameters are set" << std::endl; 
+   std::cout << "Parameters are set" << std::endl;
    // Analyze Data
    DataAnalyzer analyzer(par.input.c_str(), par.output.c_str(), "Data");
    analyzer.analyze(par);
    analyzer.writeHistograms(analyzer.outf);
    cout <<endl<<endl<<"Good good"<<endl;
-   saveParametersToHistograms(par, analyzer.outf);   
+   saveParametersToHistograms(par, analyzer.outf);
    cout << "done!" << analyzer.outf->GetName() << endl;
 }

--- a/MainAnalysis/20241029_DzeroUPC/DzeroUPC.cpp
+++ b/MainAnalysis/20241029_DzeroUPC/DzeroUPC.cpp
@@ -37,7 +37,7 @@ bool dzeroSelection(DzeroUPCTreeMessenger *b, Parameters par, int j) {
 //============================================================//
 bool eventSelection(DzeroUPCTreeMessenger *b, const Parameters &par) {
   if (par.IsData == false) return true;
-  if (b->selectedBkgFilter == false || b->selectedBkgFilter == false) return false;
+  if (b->selectedBkgFilter == false || b->selectedVtxFilter == false) return false;
   if (par.IsGammaN && (b->ZDCgammaN && b->gapgammaN) == false) return false;
   if (!par.IsGammaN && (b->ZDCNgamma && b->gapNgamma) == false) return false;
   if (par.TriggerChoice == 1 && b->isL1ZDCOr == false) return false;
@@ -65,14 +65,13 @@ bool getCorrectedYields(DzeroUPCTreeMessenger *MDzeroUPC, TH1D *hDmass,
       Bar.Print();
     }
     // Check if the event passes the selection criteria
-    //if (1) {
     if (eventSelection(MDzeroUPC, par)) {
       for (unsigned long j = 0; j < MDzeroUPC->Dalpha->size(); j++) {
         if (MDzeroUPC->Dpt->at(j) < par.MinDzeroPT) continue;
         if (MDzeroUPC->Dpt->at(j) > par.MaxDzeroPT) continue;
         if (MDzeroUPC->Dy->at(j) < par.MinDzeroY) continue;
         if (MDzeroUPC->Dy->at(j) > par.MaxDzeroY) continue;
-        if (!MDzeroUPC->DpassCut) continue;
+        if (MDzeroUPC->DpassCut->at(j) == false) continue;
         hDmass->Fill((*MDzeroUPC->Dmass)[j]);
         nt->Fill((*MDzeroUPC->Dmass)[j]);
       }

--- a/MainAnalysis/20241029_DzeroUPC/analysis_example.sh
+++ b/MainAnalysis/20241029_DzeroUPC/analysis_example.sh
@@ -1,0 +1,18 @@
+source clean.sh
+rm *.root
+PTMIN=5
+PTMAX=8
+YMIN=-1
+YMAX=0
+TRIGGER=2
+ISGAMMAN=1
+ISDATA=1
+#INPUT=/data/NewSkims23_24/20241106_SkimOldReco23sample_DataAll.root
+INPUT=/data/NewSkims23_24/20241107_SkimOldReco23sample_DataAll_RejectMode.root
+OUTPUTANALYSIS=outputpt.root
+OUTPUTFIT=outputfit.root
+./ExecuteDzeroUPC --Input $INPUT --MinDzeroPT $PTMIN --MaxDzeroPT $PTMAX --MinDzeroY $YMIN --MaxDzeroY $YMAX --IsGammaN $ISGAMMAN --TriggerChoice $TRIGGER --IsData $ISDATA --Output $OUTPUTANALYSIS
+wait
+wait
+./MassFit --Input $OUTPUTANALYSIS --Output $OUTPUTFIT
+wait

--- a/MainAnalysis/20241029_DzeroUPC/analysis_example.sh
+++ b/MainAnalysis/20241029_DzeroUPC/analysis_example.sh
@@ -3,12 +3,13 @@ rm *.root
 PTMIN=5
 PTMAX=8
 YMIN=-1
-YMAX=0
+YMAX=+0
 TRIGGER=2
 ISGAMMAN=1
 ISDATA=1
-#INPUT=/data/NewSkims23_24/20241106_SkimOldReco23sample_DataAll.root
-INPUT=/data/NewSkims23_24/20241107_SkimOldReco23sample_DataAll_RejectMode.root
+#INPUT=../../SampleGeneration/20241027_ForestReducer_DzeroUPC/Output/example.root
+INPUT=/data/NewSkims23_24/20241106_SkimOldReco23sample_DataAll.root
+#INPUT=/data/NewSkims23_24/20241107_SkimOldReco23sample_DataAll_RejectMode.root
 OUTPUTANALYSIS=outputpt.root
 OUTPUTFIT=outputfit.root
 ./ExecuteDzeroUPC --Input $INPUT --MinDzeroPT $PTMIN --MaxDzeroPT $PTMAX --MinDzeroY $YMIN --MaxDzeroY $YMAX --IsGammaN $ISGAMMAN --TriggerChoice $TRIGGER --IsData $ISDATA --Output $OUTPUTANALYSIS

--- a/MainAnalysis/20241029_DzeroUPC/clean.sh
+++ b/MainAnalysis/20241029_DzeroUPC/clean.sh
@@ -1,4 +1,5 @@
-rm Execute
+rm ExecuteDzeroUPC
+rm MassFit
 rm -rf ../../CommonCode/binary/
 rm -rf ../../CommonCode/library/
 rm -rf Output
@@ -9,7 +10,7 @@ rm *.txt*
 rm SkimReco.root
 rm .DS_Store
 
-cd /home/ginnocen/CMSSW_13_2_6_patch2/src
+cd /home/ginnocen/CMSSW_13_2_4/src
 cmsenv
 
 cd -

--- a/MainAnalysis/20241029_DzeroUPC/include/parameter.h
+++ b/MainAnalysis/20241029_DzeroUPC/include/parameter.h
@@ -3,18 +3,21 @@
 //============================================================//
 class Parameters {
 public:
-    Parameters( float MinDzeroPT, float MaxDzeroPT, float MinDzeroY, float MaxDzeroY, float MaxDalpha, float scaleFactor = 1.0)
-    : MinDzeroPT(MinDzeroPT), MaxDzeroPT(MaxDzeroPT), MinDzeroY(MinDzeroY), MaxDzeroY(MaxDzeroY), MaxDalpha(MaxDalpha), scaleFactor(scaleFactor) {}
-    string input;          // Input file name
-    string output;         // Output file name
-    float MinDzeroPT;      // Lower limit of Dzero pt
-    float MaxDzeroPT;      // Upper limit of Dzero pt
-    float MinDzeroY;       // Lower limit of Dzero rapidity
-    float MaxDzeroY;       // Upper limit of Dzero rapidity
-    float MaxDalpha;          // MaxDalpha
-    float scaleFactor;     // Scale factor
-    int nThread;           // Number of Threads
-    int nChunk;            // Process the Nth chunk
+    Parameters( float MinDzeroPT, float MaxDzeroPT, float MinDzeroY, float MaxDzeroY, bool IsGammaN, int TriggerChoice, bool IsData, float scaleFactor = 1.0)
+	: MinDzeroPT(MinDzeroPT), MaxDzeroPT(MaxDzeroPT), MinDzeroY(MinDzeroY), MaxDzeroY(MaxDzeroY), IsGammaN(IsGammaN), TriggerChoice(TriggerChoice), IsData(IsData), scaleFactor(scaleFactor) {}
+    Parameters() {}
+   string input;          // Input file name
+   string output;         // Output file name
+   float MinDzeroPT;      // Lower limit of Dzero pt
+   float MaxDzeroPT;      // Upper limit of Dzero pt
+   float MinDzeroY;       // Lower limit of Dzero rapidity
+   float MaxDzeroY;       // Upper limit of Dzero rapidity
+   bool IsGammaN;         // GammaN analysis (or NGamma)
+   int TriggerChoice;     // 0 = no trigger sel, 1 = isL1ZDCOr, 2 = isL1ZDCXORJet8
+   bool IsData;           // Data or MC
+   float scaleFactor;     // Scale factor
+   int nThread;           // Number of Threads
+   int nChunk;            // Process the Nth chunk
    void printParameters() const {
        cout << "Input file: " << input << endl;
        cout << "Output file: " << output << endl;
@@ -22,7 +25,9 @@ public:
        cout << "MaxDzeroPT: " << MaxDzeroPT << endl;
        cout << "MinDzeroY: " << MinDzeroY << endl;
        cout << "MaxDzeroY: " << MaxDzeroY << endl;
-       cout << "MaxDalpha: " << MaxDalpha << endl;
+       cout << "IsGammaN: " << IsGammaN << endl; 
+       cout << "TriggerChoice: " << TriggerChoice << endl;
+       cout << "IsData: " << IsData << endl;
        cout << "Scale factor: " << scaleFactor << endl;
        cout << "Number of Threads: " << nThread << endl;
        cout << "Process the Nth chunk: " << nChunk << endl;
@@ -44,8 +49,12 @@ void saveParametersToHistograms(const Parameters& par, TFile* outf) {
     hMinDzeroY->SetBinContent(1, par.MinDzeroY);
     TH1D* hMaxDzeroY = new TH1D("parMaxDzeroY", "parMaxDzeroY", 1, 0, 1);
     hMaxDzeroY->SetBinContent(1, par.MaxDzeroY);
-    TH1D* hMaxDalpha = new TH1D("parMaxDalpha", "parMaxDalpha", 1, 0, 1);
-    hMaxDalpha->SetBinContent(1, par.MaxDalpha);
+    TH1D* hIsGammaN = new TH1D("parIsGammaN", "parIsGammaN", 1, 0, 1);
+    hIsGammaN->SetBinContent(1, par.IsGammaN);
+    TH1D* hTriggerChoice = new TH1D("parTriggerChoice", "parTriggerChoice", 1, 0, 1);
+    hTriggerChoice->SetBinContent(1, par.TriggerChoice);
+    TH1D* hIsData = new TH1D("parIsData", "parIsData", 1, 0, 1);
+    hIsData->SetBinContent(1, par.IsData);
     TH1D* hScaleFactor = new TH1D("parScaleFactor", "parScaleFactor", 1, 0, 1);
     hScaleFactor->SetBinContent(1, par.scaleFactor);
     
@@ -54,7 +63,9 @@ void saveParametersToHistograms(const Parameters& par, TFile* outf) {
     hMaxDzeroPT->Write();
     hMinDzeroY->Write();
     hMaxDzeroY->Write();
-    hMaxDalpha->Write();
+    hIsGammaN->Write();
+    hTriggerChoice->Write();
+    hIsData->Write();
     hScaleFactor->Write();
 
     // Clean up
@@ -62,6 +73,8 @@ void saveParametersToHistograms(const Parameters& par, TFile* outf) {
     delete hMaxDzeroPT;
     delete hMinDzeroY;
     delete hMaxDzeroY;
-    delete hMaxDalpha;
+    delete hIsGammaN;
+    delete hTriggerChoice;
+    delete hIsData;
     delete hScaleFactor;
 }

--- a/MainAnalysis/20241029_DzeroUPC/massfit.C
+++ b/MainAnalysis/20241029_DzeroUPC/massfit.C
@@ -17,9 +17,10 @@
 using namespace std;
 using namespace RooFit;
 
-void main_fit(TTree *datatree) {
+void main_fit(TTree *datatree, string outputstring) {
+    TCanvas* canvas = new TCanvas("canvas", "Fit Plot", 800, 600);
     // Define the mass range and variables
-    RooRealVar m("Dmass", "Mass [GeV]", 1.76, 1.96);
+    RooRealVar m("Dmass", "Mass [GeV]", 1.68, 2.05);
 
     // Define the signal model: double Gaussian
     RooRealVar mean("mean", "mean", 1.86484, 1.85, 1.88);
@@ -47,14 +48,13 @@ void main_fit(TTree *datatree) {
     RooFitResult* result = model.fitTo(data, Save());
 
     // Plot the data and the fit result
-    TCanvas* canvas = new TCanvas("canvas", "Fit Plot", 800, 600);
     RooPlot* frame = m.frame();
     data.plotOn(frame);
     model.plotOn(frame);
     model.plotOn(frame, Components(background), LineStyle(kDashed), LineColor(kRed));
     frame->Draw();
+    canvas->SaveAs(Form("fit_result%s.pdf", outputstring.c_str()));
     
-    canvas->SaveAs("fit_result.pdf");
 }
 
 
@@ -63,11 +63,10 @@ int main(int argc, char *argv[]) {
   CommandLine CL(argc, argv);
   string input         = CL.Get      ("Input",   "output.root"); // Input file
   string output        = CL.Get      ("Output",  "fit.root");    // Output file
-  
+  string outputstring  = CL.Get      ("Label",   "label");       // Label for output file
   TFile *inf  = new TFile(input.c_str());
   TFile *outf = new TFile(output.c_str());
-  
   TTree *t = (TTree*) inf->Get("nt");
-  main_fit(t);
-}
+  main_fit(t, outputstring);
 
+}

--- a/MainAnalysis/20241029_DzeroUPC/workflow/analysis_example.sh
+++ b/MainAnalysis/20241029_DzeroUPC/workflow/analysis_example.sh
@@ -1,6 +1,0 @@
- .././ExecuteDzeroUPC --Input /data/NewSkims23_24/20241102_SkimOldReco23sample_DataAllPDs/MergedSkim.root  --MinDzeroPT 5 --MaxDzeroPT 8 --MinDzeroY -2 --MaxDzeroY -1 --Output outputUPCpt5to8_ym2ym1.root &
- .././ExecuteDzeroUPC --Input /data/NewSkims23_24/20241102_SkimOldReco23sample_DataAllPDs/MergedSkim.root  --MinDzeroPT 5 --MaxDzeroPT 8 --MinDzeroY -1 --MaxDzeroY 0 --Output outputUPCpt5to8_ym1to0.root &
- .././ExecuteDzeroUPC --Input /data/NewSkims23_24/20241102_SkimOldReco23sample_DataAllPDs/MergedSkim.root  --MinDzeroPT 5 --MaxDzeroPT 8 --MinDzeroY 0 --MaxDzeroY 1 --Output outputUPCpt5to8_y0to1.root &
- .././ExecuteDzeroUPC --Input /data/NewSkims23_24/20241102_SkimOldReco23sample_DataAllPDs/MergedSkim.root  --MinDzeroPT 5 --MaxDzeroPT 8 --MinDzeroY 1 --MaxDzeroY 2 --Output outputUPCpt5to8_y1to2.root &
-wait
-wait

--- a/SampleGeneration/20241027_ForestReducer_DzeroUPC/ReduceForest.cpp
+++ b/SampleGeneration/20241027_ForestReducer_DzeroUPC/ReduceForest.cpp
@@ -24,6 +24,10 @@ using namespace std;
 
 #include "include/DmesonSelection.h"
 
+bool logical_or_vectBool(std::vector<bool>* vec) {
+    return std::any_of(vec->begin(), vec->end(), [](bool b) { return b; });
+}
+
 int main(int argc, char *argv[]);
 double GetMaxEnergyHF(PFTreeMessenger *M, double etaMin, double etaMax);
 
@@ -39,7 +43,8 @@ int main(int argc, char *argv[]) {
   bool IsData = CL.GetBool("IsData", false);
   int Year = CL.GetInt("Year", 2023);
   double Fraction = CL.GetDouble("Fraction", 1.00);
-  bool ApplyDPreselection = CL.GetBool("ApplyDPreselection", true);
+  bool ApplyEventRejection = CL.GetBool("ApplyEventRejection", true);
+  bool ApplyDRejection = CL.GetBool("ApplyDRejection", true);
   string PFTreeName = CL.Get("PFTree", "particleFlowAnalyser/pftree");
   string DGenTreeName = CL.Get("DGenTree", "Dfinder/ntGen");
   TFile OutputFile(OutputFileName.c_str(), "RECREATE");
@@ -139,6 +144,7 @@ int main(int argc, char *argv[]) {
         MDzeroUPC.ZDCsumMinus = MZDC.sumMinus;
         bool selectedBkgFilter = MSkim.ClusterCompatibilityFilter == 1 && MMETFilter.cscTightHalo2015Filter;
         bool selectedVtxFilter = MSkim.PVFilter == 1 && fabs(MTrackPbPbUPC.zVtx->at(0)) < 15.;
+        if (selectedBkgFilter == false || selectedVtxFilter == false) continue;
         MDzeroUPC.selectedBkgFilter = selectedBkgFilter;
         MDzeroUPC.selectedVtxFilter = selectedVtxFilter;
         int HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000_2023 =
@@ -153,8 +159,8 @@ int main(int argc, char *argv[]) {
                          HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000_2023 == 1;
         bool isL1ZDCXORJet8 = HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000_2023 == 1 ||
                               HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000_2023 == 1;
-        // if (isL1ZDCOr == false && isL1ZDCXORJet8 == false)
-        //   continue;
+        if (isL1ZDCOr == false && isL1ZDCXORJet8 == false)
+           continue;
         MDzeroUPC.isL1ZDCOr = isL1ZDCOr;
         MDzeroUPC.isL1ZDCXORJet8 = isL1ZDCXORJet8;
         bool ZDCgammaN = (MZDC.sumMinus > 1100. && MZDC.sumPlus < 1100.);
@@ -181,6 +187,8 @@ int main(int argc, char *argv[]) {
           bool Ngamma_ = ZDCNgamma && gapNgamma;
           MDzeroUPC.Ngamma->push_back(Ngamma_);
         }
+        //bool evtselgammaNNgamma = logical_or_vectBool(MDzeroUPC.gammaN) || logical_or_vectBool(MDzeroUPC.Ngamma);
+        //if (ApplyEventRejection && evtselgammaNNgamma == false) continue;
       } // end of if (IsData == true)
       int nTrackInAcceptanceHP = 0;
       for (int iTrack = 0; iTrack < MTrackPbPbUPC.nTrk; iTrack++) {
@@ -195,7 +203,7 @@ int main(int argc, char *argv[]) {
       MDzeroUPC.nTrackInAcceptanceHP = nTrackInAcceptanceHP;
       int countSelDzero = 0;
       for (int iD = 0; iD < MDzero.Dsize; iD++) {
-        if (ApplyDPreselection && DmesonSelectionSkimPrelim23(MDzero, iD) == false) continue;
+        //if (ApplyDRejection && DmesonSelectionPrelim23(MDzero, iD) == false) continue;
         countSelDzero++;
         MDzeroUPC.Dpt->push_back(MDzero.Dpt[iD]);
         MDzeroUPC.Dy->push_back(MDzero.Dy[iD]);

--- a/SampleGeneration/20241027_ForestReducer_DzeroUPC/ReduceForest.cpp
+++ b/SampleGeneration/20241027_ForestReducer_DzeroUPC/ReduceForest.cpp
@@ -177,6 +177,10 @@ int main(int argc, char *argv[]) {
         bool gapNgamma = EMaxHFMinus < 8.6;
         MDzeroUPC.gapgammaN = gapgammaN;
         MDzeroUPC.gapNgamma = gapNgamma;
+        bool gammaN_default = ZDCgammaN && gapgammaN;
+        bool Ngamma_default = ZDCNgamma && gapNgamma;
+        if (gammaN_default == false && Ngamma_default == false) continue;
+
         for (double gapgammaN_threshold = 5.2; gapgammaN_threshold <= 13.2; gapgammaN_threshold += 1.0) {
           bool gapgammaN = GetMaxEnergyHF(&MPF, 3.0, 5.2) < gapgammaN_threshold;
           bool gammaN_ = ZDCgammaN && gapgammaN;
@@ -203,7 +207,7 @@ int main(int argc, char *argv[]) {
       MDzeroUPC.nTrackInAcceptanceHP = nTrackInAcceptanceHP;
       int countSelDzero = 0;
       for (int iD = 0; iD < MDzero.Dsize; iD++) {
-        //if (ApplyDRejection && DmesonSelectionPrelim23(MDzero, iD) == false) continue;
+        if (DmesonSelectionPrelim23(MDzero, iD) == false) continue;
         countSelDzero++;
         MDzeroUPC.Dpt->push_back(MDzero.Dpt[iD]);
         MDzeroUPC.Dy->push_back(MDzero.Dy[iD]);

--- a/SampleGeneration/20241027_ForestReducer_DzeroUPC/RunParallelData.sh
+++ b/SampleGeneration/20241027_ForestReducer_DzeroUPC/RunParallelData.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
-MAXCORES=100
+MAXCORES=120
 
-NAME="20241106_SkimOldReco23sample_DataAll"
+NAME="20241107bis_SkimOldReco23sample_DataAll_RejectMode"
 OUTPUT="output"
 counter=0
 filelist="/data/NewSkims23_24/InputLists/20241106_filelist_SkimOldReco23sample_DataAll.txt"
 MERGEDOUTPUT="/data/NewSkims23_24/$NAME.root"
 rm $MERGEDOUTPUT
+
+# Function to monitor active processes
+wait_for_slot() {
+    while (( $(jobs -r | wc -l) >= MAXCORES )); do
+        # Wait a bit before checking again
+        sleep 1
+    done
+}
+
 
 # Check if the filelist is empty
 if [[ ! -s "$filelist" ]]; then
@@ -28,9 +37,10 @@ while IFS= read -r file; do
             --PFTree particleFlowAnalyser/pftree &
  #           --DGenTree Dfinder/ntGen &
     ((counter++))
-    if (( counter % $MAXCORES == 0 )); then
-        wait
-    fi
+    wait_for_slot
+    #if (( counter % $MAXCORES == 0 )); then
+    #    wait
+    #fi
 done < "$filelist"
 wait 
 

--- a/SampleGeneration/20241027_ForestReducer_DzeroUPC/RunParallelData.sh
+++ b/SampleGeneration/20241027_ForestReducer_DzeroUPC/RunParallelData.sh
@@ -37,7 +37,10 @@ while IFS= read -r file; do
             --PFTree particleFlowAnalyser/pftree &
  #           --DGenTree Dfinder/ntGen &
     ((counter++))
-    wait_for_slot
+    #wait_for_slot
+    if (( counter % $MAXCORES == 0 )); then
+        wait
+    fi
     #if (( counter % $MAXCORES == 0 )); then
     #    wait
     #fi

--- a/SampleGeneration/20241027_ForestReducer_DzeroUPC/RunParallelData.sh
+++ b/SampleGeneration/20241027_ForestReducer_DzeroUPC/RunParallelData.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 MAXCORES=120
 
-NAME="20241107bis_SkimOldReco23sample_DataAll_RejectMode"
+NAME="20241110_SkimOldReco23sample_DataAll_RejectMode"
 OUTPUT="output"
 counter=0
 filelist="/data/NewSkims23_24/InputLists/20241106_filelist_SkimOldReco23sample_DataAll.txt"
@@ -37,10 +37,10 @@ while IFS= read -r file; do
             --PFTree particleFlowAnalyser/pftree &
  #           --DGenTree Dfinder/ntGen &
     ((counter++))
-    #wait_for_slot
-    if (( counter % $MAXCORES == 0 )); then
-        wait
-    fi
+    wait_for_slot
+    #if (( counter % $MAXCORES == 0 )); then
+    #    wait
+    #fi
     #if (( counter % $MAXCORES == 0 )); then
     #    wait
     #fi

--- a/SampleGeneration/20241027_ForestReducer_DzeroUPC/RunParallelMC.sh
+++ b/SampleGeneration/20241027_ForestReducer_DzeroUPC/RunParallelMC.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 MAXCORES=100
 
-NAMEMC="20241106_filelist_SkimOldReco23sample_MCPthat2"
+NAMEMC="20241107_filelist_SkimOldReco23sample_MCPthat2"
 OUTPUTMC="outputMC"
 counterMC=0
 filelistMC="/data/NewSkims23_24/InputLists/20241106_filelist_SkimOldReco23sample_MCPthat2.txt"

--- a/SampleGeneration/20241027_ForestReducer_DzeroUPC/clean.sh
+++ b/SampleGeneration/20241027_ForestReducer_DzeroUPC/clean.sh
@@ -10,7 +10,7 @@ rm *.txt*
 rm SkimReco.root
 rm .DS_Store
 
-cd /home/ginnocen/CMSSW_13_2_6_patch2/src
+cd /home/ginnocen/CMSSW_13_2_4/src
 cmsenv
 
 cd -


### PR DESCRIPTION
- Add rejection in the UPC reducer
- Reducer validated against the old skimmer
- add options for analysis
- fit included in the workflow
- FIXME: multi-threading is disabled for the moment.