### PR TITLE
[new] skim validation tools

### DIFF
--- a/MainAnalysis/20241110_SkimValidation/DumpNewSkim.cpp
+++ b/MainAnalysis/20241110_SkimValidation/DumpNewSkim.cpp
@@ -1,0 +1,164 @@
+/* + Descriptions:
+ *		Macro to dump the new skim format into .txt and histograms in .root, for the validations btw two skims
+ * + Output:
+ * 		+ .txt:  printing of event-, reco-D- and gen-D-level quantities
+ * 		+ .root: contains histograms defined in ValidateHist.h
+ * + Todo:
+ *		+ The current MC skim doesn't have the gammaN, Ngamma info, so I assume 0 for the current being
+ */
+#include <cstdio>
+#include <iostream>
+#include <string>
+using namespace std;
+
+#include "TFile.h"
+#include "TTree.h"
+
+#include "CommandLine.h"
+#include "CommonFunctions.h"
+#include "Messenger.h"
+#include "ProgressBar.h"
+
+#include "ValidateHist.h"
+
+int main(int argc, char *argv[]) {
+  CommandLine CL(argc, argv);
+
+  string InputFileName = CL.Get("Input");
+  string OutputName = CL.Get("Output");
+  bool IsData = CL.GetBool("IsData");
+
+  double Fraction = CL.GetDouble("Fraction", 1.00);
+  bool ApplyEventSelection = CL.GetBool("ApplyEventSelection", true);
+  double SkimDzeroPresenceAbovePTMin = CL.GetDouble("SkimDzeroPresenceAbovePTMin", 2.);
+  bool ApplyDSelection = CL.GetBool("ApplyDSelection", false);
+
+  TFile InputFile(InputFileName.c_str());
+
+  DzeroUPCTreeMessenger MDzeroUPC(InputFile, "Tree", true);
+
+  FILE *outfile = fopen((OutputName + ".txt").c_str(), "w");
+  if (outfile == nullptr) {
+    perror("Error opening outfile");
+    exit(EXIT_FAILURE);
+  }
+
+  ValidateHist v((OutputName + ".root").c_str(), "recreate");
+
+  int EntryCount = MDzeroUPC.GetEntries() * Fraction;
+  ProgressBar Bar(cout, EntryCount);
+  Bar.SetStyle(-1);
+
+  for (int iE = 0; iE < EntryCount; iE++) {
+    if (EntryCount < 300 || (iE % (EntryCount / 250)) == 0) {
+      Bar.Update(iE);
+      Bar.Print();
+    }
+
+    MDzeroUPC.GetEntry(iE);
+
+    bool DRequirement = false;
+    for (int iD = 0; iD < MDzeroUPC.Dpt->size(); ++iD) {
+      if (MDzeroUPC.Dpt->at(iD) > SkimDzeroPresenceAbovePTMin) {
+        DRequirement = true;
+        break;
+      }
+    }
+
+    bool passEventSelection = (IsData) ? (MDzeroUPC.isL1ZDCOr || MDzeroUPC.isL1ZDCXORJet8) &&
+                                             MDzeroUPC.selectedBkgFilter && MDzeroUPC.selectedVtxFilter &&
+                                             (MDzeroUPC.gammaN->at(4) || MDzeroUPC.Ngamma->at(4)) && DRequirement
+                                       : true; // don't skim on MC
+    if (ApplyEventSelection && !passEventSelection)
+      continue;
+
+    if (IsData) {
+      fprintf(outfile,
+              // "[Entry %d] "
+              "Run %d, Lumi %d, Event %d\n"
+              "isL1ZDCOr %d, isL1ZDCXORJet8 %d\n"
+              "selectedBkgFilter %d, selectedVtxFilter %d\n"
+              "gammaN %d, Ngamma %d\n"
+              "VX %f VY %f VZ %f\n"
+              "VXError %f VYError %f VZError %f\n"
+              "Dsize %d\n", // Dpt->size() %d\n",
+              // iE,
+              MDzeroUPC.Run, MDzeroUPC.Lumi, MDzeroUPC.Event, (int)MDzeroUPC.isL1ZDCOr, (int)MDzeroUPC.isL1ZDCXORJet8,
+              (int)MDzeroUPC.selectedBkgFilter, (int)MDzeroUPC.selectedVtxFilter, (int)(MDzeroUPC.gammaN->at(4)),
+              (int)(MDzeroUPC.Ngamma->at(4)), MDzeroUPC.VX, MDzeroUPC.VY, MDzeroUPC.VZ, MDzeroUPC.VXError,
+              MDzeroUPC.VYError, MDzeroUPC.VZError, MDzeroUPC.Dsize);
+
+      v.FillEventInfo(MDzeroUPC.Run, MDzeroUPC.Lumi, MDzeroUPC.Event, MDzeroUPC.VX, MDzeroUPC.VY, MDzeroUPC.VZ,
+                      MDzeroUPC.VXError, MDzeroUPC.VYError, MDzeroUPC.VZError, MDzeroUPC.Dsize);
+    } else {
+      fprintf(outfile,
+              // "[Entry %d] "
+              "Run %d, Lumi %d, Event %d\n"
+              "VX %f VY %f VZ %f\n"
+              "VXError %f VYError %f VZError %f\n"
+              "Dsize %d Gsize %d\n", // Dpt->size() %d\n",
+              // iE,
+              MDzeroUPC.Run, MDzeroUPC.Lumi, MDzeroUPC.Event, MDzeroUPC.VX, MDzeroUPC.VY, MDzeroUPC.VZ,
+              MDzeroUPC.VXError, MDzeroUPC.VYError, MDzeroUPC.VZError, MDzeroUPC.Dsize, MDzeroUPC.Gsize);
+
+      v.FillEventInfo(MDzeroUPC.Run, MDzeroUPC.Lumi, MDzeroUPC.Event, MDzeroUPC.VX, MDzeroUPC.VY, MDzeroUPC.VZ,
+                      MDzeroUPC.VXError, MDzeroUPC.VYError, MDzeroUPC.VZError, MDzeroUPC.Dsize, MDzeroUPC.Gsize);
+    }
+
+    v.FillEventSelectionInfo((int)MDzeroUPC.isL1ZDCOr, (int)MDzeroUPC.isL1ZDCXORJet8, (int)MDzeroUPC.selectedBkgFilter,
+                             (int)MDzeroUPC.selectedVtxFilter, (IsData) ? (int)(MDzeroUPC.gammaN->at(4)) : 0,
+                             (IsData) ? (int)(MDzeroUPC.Ngamma->at(4)) : 0);
+
+    for (int iD = 0; iD < MDzeroUPC.Dpt->size(); ++iD) {
+      bool passDSelection = MDzeroUPC.DpassCut->at(iD);
+      if (ApplyDSelection && !passDSelection)
+        continue;
+
+      fprintf(outfile,
+              "[D %d] "
+              "Dpt %f Dy %f Dmass %f\n"
+              "Dtrk1Pt %f Dtrk2Pt %f\n"
+              "Dchi2cl %f DsvpvDistance %f DsvpvDisErr %f\n"
+              "Dalpha %f DsvpvDistance_2D %f DsvpvDisErr_2D %f\n"
+              "Ddtheta %f\n",
+              iD, MDzeroUPC.Dpt->at(iD), MDzeroUPC.Dy->at(iD), MDzeroUPC.Dmass->at(iD), MDzeroUPC.Dtrk1Pt->at(iD),
+              MDzeroUPC.Dtrk2Pt->at(iD), MDzeroUPC.Dchi2cl->at(iD), MDzeroUPC.DsvpvDistance->at(iD),
+              MDzeroUPC.DsvpvDisErr->at(iD), MDzeroUPC.Dalpha->at(iD), MDzeroUPC.DsvpvDistance_2D->at(iD),
+              MDzeroUPC.DsvpvDisErr_2D->at(iD), MDzeroUPC.Ddtheta->at(iD));
+
+      v.FillRecoDInfo(MDzeroUPC.Dpt->at(iD), MDzeroUPC.Dy->at(iD), MDzeroUPC.Dmass->at(iD), MDzeroUPC.Dtrk1Pt->at(iD),
+                      MDzeroUPC.Dtrk2Pt->at(iD), MDzeroUPC.Dchi2cl->at(iD), MDzeroUPC.DsvpvDistance->at(iD),
+                      MDzeroUPC.DsvpvDisErr->at(iD), MDzeroUPC.Dalpha->at(iD), MDzeroUPC.DsvpvDistance_2D->at(iD),
+                      MDzeroUPC.DsvpvDisErr_2D->at(iD), MDzeroUPC.Ddtheta->at(iD));
+
+      if (!IsData) {
+        fprintf(outfile, "Dgen %d DisSignalCalc %d DisSignalCalcPrompt %d DisSignalCalcFeeddown %d\n",
+                MDzeroUPC.Dgen->at(iD), (int)(MDzeroUPC.DisSignalCalc->at(iD)),
+                (int)(MDzeroUPC.DisSignalCalcPrompt->at(iD)), (int)(MDzeroUPC.DisSignalCalcFeeddown->at(iD)));
+
+        v.FillRecoDGenMatchedInfo(MDzeroUPC.Dgen->at(iD), (int)(MDzeroUPC.DisSignalCalc->at(iD)),
+                                  (int)(MDzeroUPC.DisSignalCalcPrompt->at(iD)),
+                                  (int)(MDzeroUPC.DisSignalCalcFeeddown->at(iD)));
+      }
+    }
+
+    if (!IsData) {
+      for (int iG = 0; iG < MDzeroUPC.Gpt->size(); ++iG) {
+        fprintf(outfile,
+                "[G %d] "
+                "Gpt %f Gy %f\n"
+                "GisSignalCalc %d GisSignalCalcPrompt %d GisSignalCalcFeeddown %d\n",
+                iG, MDzeroUPC.Gpt->at(iG), MDzeroUPC.Gy->at(iG), (int)(MDzeroUPC.GisSignalCalc->at(iG)),
+                (int)(MDzeroUPC.GisSignalCalcPrompt->at(iG)), (int)(MDzeroUPC.GisSignalCalcFeeddown->at(iG)));
+
+        v.FillGenDInfo(MDzeroUPC.Gpt->at(iG), MDzeroUPC.Gy->at(iG), (int)(MDzeroUPC.GisSignalCalc->at(iG)),
+                       (int)(MDzeroUPC.GisSignalCalcPrompt->at(iG)), (int)(MDzeroUPC.GisSignalCalcFeeddown->at(iG)));
+      }
+    }
+  }
+  v.Write();
+
+  fclose(outfile);
+
+  return 0;
+}

--- a/MainAnalysis/20241110_SkimValidation/DumpOldSkim.cpp
+++ b/MainAnalysis/20241110_SkimValidation/DumpOldSkim.cpp
@@ -1,0 +1,446 @@
+/* + Descriptions:
+ *		Macro to dump the old skim format into .txt and histograms in .root, for the validations btw two skims
+ * + Output:
+ * 		+ .txt:  printing of event-, reco-D- and gen-D-level quantities
+ * 		+ .root: contains histograms defined in ValidateHist.h
+ */
+#include <cstdio>
+#include <iostream>
+#include <string>
+using namespace std;
+
+#include "TFile.h"
+#include "TH2D.h"
+#include "TTree.h"
+
+#include "CommandLine.h"
+#include "CommonFunctions.h"
+#include "Messenger.h"
+#include "ProgressBar.h"
+
+#include "ValidateHist.h"
+
+// copy from main analysis
+void calcRapidityGapsInput(std::vector<float> *pfE, std::vector<float> *pfPt, std::vector<float> *pfEta,
+                           std::vector<int> *pfId, int &nPFHFMinus_, int &nPFHFPlus_);
+
+bool tightsel(int j, DzeroTreeMessenger &MDzero, std::string varySel = "");
+
+int findBestVertex(PbPbUPCTrackTreeMessenger &MTrackPbPbUPC) {
+  int BestVertex = -1;
+
+  for (int i = 0; i < MTrackPbPbUPC.nVtx; i++) {
+    if (BestVertex < 0 || MTrackPbPbUPC.ptSumVtx->at(i) > MTrackPbPbUPC.ptSumVtx->at(BestVertex))
+      BestVertex = i;
+  }
+
+  return BestVertex;
+}
+int main(int argc, char *argv[]) {
+  CommandLine CL(argc, argv);
+
+  string InputFileName = CL.Get("Input");
+  string OutputName = CL.Get("Output");
+  bool IsData = CL.GetBool("IsData");
+
+  double Fraction = CL.GetDouble("Fraction", 1.00);
+  bool ApplyEventSelection = CL.GetBool("ApplyEventSelection", true);
+  double SkimDzeroPresenceAbovePTMin = CL.GetDouble("SkimDzeroPresenceAbovePTMin", 2.);
+  bool ApplyDSelection = CL.GetBool("ApplyDSelection", false);
+  double MinDzeroPT = CL.GetDouble("MinDzeroPT", 2.);
+  double MaxDzeroPT = CL.GetDouble("MaxDzeroPT", 12.);
+  double MinDzeroY = CL.GetDouble("MinDzeroY", -2.);
+  double MaxDzeroY = CL.GetDouble("MaxDzeroY", 2.);
+  string PFTreeName = CL.Get("PFTree", "particleFlowAnalyser/pftree");
+  string DGenTreeName = CL.Get("DGenTree", "Dfinder/ntGen");
+
+  TFile InputFile(InputFileName.c_str());
+  HiEventTreeMessenger MEvent(InputFile);
+  PbPbUPCTrackTreeMessenger MTrackPbPbUPC(InputFile);
+  GenParticleTreeMessenger MGen(InputFile);
+  PFTreeMessenger MPF(InputFile, PFTreeName);
+  SkimTreeMessenger MSkim(InputFile);
+  TriggerTreeMessenger MTrigger(InputFile);
+  DzeroTreeMessenger MDzero(InputFile);
+  DzeroGenTreeMessenger MDzeroGen(InputFile, DGenTreeName);
+  ZDCTreeMessenger MZDC(InputFile);
+  METFilterTreeMessenger MMETFilter(InputFile);
+
+  TTree *tt = (TTree *)InputFile.Get("ppTracks/trackTree");
+  int Run;
+  int Event;
+  int Lumi;
+  tt->SetBranchAddress("nRun", &Run);
+  tt->SetBranchAddress("nLumi", &Lumi);
+  tt->SetBranchAddress("nEv", &Event);
+
+  TTree *ht = (TTree *)InputFile.Get("hltanalysis/HltTree");
+  int HLT_HIUPC_ZDC1nOR_SinglePixelTrackLowPt_MaxPixelCluster400_v8;
+  int HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000_v8;
+  // int HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000;
+  int HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000_v1;
+  ht->SetBranchAddress("HLT_HIUPC_ZDC1nOR_SinglePixelTrackLowPt_MaxPixelCluster400_v8",
+                       &HLT_HIUPC_ZDC1nOR_SinglePixelTrackLowPt_MaxPixelCluster400_v8);
+  ht->SetBranchAddress("HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000_v8",
+                       &HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000_v8);
+  // ht->SetBranchAddress("HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000",
+  // &HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000);
+  ht->SetBranchAddress("HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000_v1",
+                       &HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000_v1);
+
+  FILE *outfile = fopen((OutputName + ".txt").c_str(), "w");
+  if (outfile == nullptr) {
+    perror("Error opening outfile");
+    exit(EXIT_FAILURE);
+  }
+
+  ValidateHist v((OutputName + ".root").c_str(), "recreate");
+
+  int EntryCount = MEvent.GetEntries() * Fraction;
+  ProgressBar Bar(cout, EntryCount);
+  Bar.SetStyle(-1);
+
+  for (int iE = 0; iE < EntryCount; iE++) {
+    if (EntryCount < 300 || (iE % (EntryCount / 250)) == 0) {
+      Bar.Update(iE);
+      Bar.Print();
+    }
+
+    MEvent.GetEntry(iE);
+    MGen.GetEntry(iE);
+    MTrackPbPbUPC.GetEntry(iE);
+    MPF.GetEntry(iE);
+    MSkim.GetEntry(iE);
+    MTrigger.GetEntry(iE);
+    MDzero.GetEntry(iE);
+    if (!IsData)
+      MDzeroGen.GetEntry(iE);
+    MZDC.GetEntry(iE);
+    MMETFilter.GetEntry(iE);
+    tt->GetEntry(iE);
+    ht->GetEntry(iE);
+
+    ////////// event selection //////////
+    bool isL1ZDCOr = HLT_HIUPC_ZDC1nOR_SinglePixelTrackLowPt_MaxPixelCluster400_v8 ||
+                     HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000_v8;
+    bool isL1ZDCXORJet8 = HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000_v1;
+
+    bool selectedBkgFilter = MSkim.ClusterCompatibilityFilter == 1 && MMETFilter.cscTightHalo2015Filter;
+    bool selectedVtxFilter = MSkim.PVFilter == 1 && fabs(MTrackPbPbUPC.zVtx->at(0)) < 15. && MTrackPbPbUPC.nVtx <= 3;
+
+    bool ZDCgammaN = (MZDC.sumMinus > 1000. && MZDC.sumPlus <= 1100.);
+    bool ZDCNgamma = (MZDC.sumMinus <= 1000. && MZDC.sumPlus > 1100.);
+
+    int _nPFHFMinus, _nPFHFPlus;
+    calcRapidityGapsInput(MPF.E, MPF.PT, MPF.Eta, MPF.ID, _nPFHFMinus, _nPFHFPlus);
+    bool gapgammaN = _nPFHFPlus == 0;
+    bool gapNgamma = _nPFHFMinus == 0;
+
+    bool gammaN = ZDCgammaN && gapgammaN;
+    bool Ngamma = ZDCNgamma && gapNgamma;
+
+    bool DRequirement = false;
+    for (int iD = 0; iD < MDzero.Dsize; ++iD) {
+      if (MDzero.Dpt[iD] > SkimDzeroPresenceAbovePTMin) {
+        DRequirement = true;
+        break;
+      }
+    }
+
+    bool passEventSelection = (IsData) ? (isL1ZDCOr || isL1ZDCXORJet8) && selectedBkgFilter && selectedVtxFilter &&
+                                             (gammaN || Ngamma) && DRequirement
+                                       : true; // don't skim on MC
+    if (ApplyEventSelection && !passEventSelection)
+      continue;
+    ////////// event selection //////////
+
+    int BestVertex = findBestVertex(MTrackPbPbUPC);
+
+    if (IsData) {
+      fprintf(outfile,
+              // "[Entry %d] "
+              "Run %d, Lumi %d, Event %d\n"
+              "isL1ZDCOr %o, isL1ZDCXORJet8 %o\n"
+              "selectedBkgFilter %d, selectedVtxFilter %d\n"
+              "gammaN %d, Ngamma %d\n"
+              "VX %f VY %f VZ %f\n"
+              "VXError %f VYError %f VZError %f\n"
+              "Dsize %d\n",
+              // iE,
+              Run, Lumi, Event, isL1ZDCOr, isL1ZDCXORJet8, selectedBkgFilter, selectedVtxFilter, gammaN, Ngamma,
+              MTrackPbPbUPC.xVtx->at(BestVertex), MTrackPbPbUPC.yVtx->at(BestVertex),
+              MTrackPbPbUPC.zVtx->at(BestVertex), MTrackPbPbUPC.xErrVtx->at(BestVertex),
+              MTrackPbPbUPC.yErrVtx->at(BestVertex), MTrackPbPbUPC.zErrVtx->at(BestVertex), MDzero.Dsize);
+
+      v.FillEventInfo(Run, Lumi, Event, MTrackPbPbUPC.xVtx->at(BestVertex), MTrackPbPbUPC.yVtx->at(BestVertex),
+                      MTrackPbPbUPC.zVtx->at(BestVertex), MTrackPbPbUPC.xErrVtx->at(BestVertex),
+                      MTrackPbPbUPC.yErrVtx->at(BestVertex), MTrackPbPbUPC.zErrVtx->at(BestVertex), MDzero.Dsize);
+    } else {
+      fprintf(outfile,
+              // "[Entry %d] "
+              "Run %d, Lumi %d, Event %d\n"
+              "VX %f VY %f VZ %f\n"
+              "VXError %f VYError %f VZError %f\n"
+              "Dsize %d Gsize %d\n",
+              // iE,
+              Run, Lumi, Event, MTrackPbPbUPC.xVtx->at(BestVertex), MTrackPbPbUPC.yVtx->at(BestVertex),
+              MTrackPbPbUPC.zVtx->at(BestVertex), MTrackPbPbUPC.xErrVtx->at(BestVertex),
+              MTrackPbPbUPC.yErrVtx->at(BestVertex), MTrackPbPbUPC.zErrVtx->at(BestVertex), MDzero.Dsize,
+              MDzeroGen.Gsize);
+
+      v.FillEventInfo(Run, Lumi, Event, MTrackPbPbUPC.xVtx->at(BestVertex), MTrackPbPbUPC.yVtx->at(BestVertex),
+                      MTrackPbPbUPC.zVtx->at(BestVertex), MTrackPbPbUPC.xErrVtx->at(BestVertex),
+                      MTrackPbPbUPC.yErrVtx->at(BestVertex), MTrackPbPbUPC.zErrVtx->at(BestVertex), MDzero.Dsize,
+                      MDzeroGen.Gsize);
+    }
+
+    v.FillEventSelectionInfo(isL1ZDCOr, isL1ZDCXORJet8, selectedBkgFilter, selectedVtxFilter, gammaN, Ngamma);
+
+    for (int iD = 0; iD < MDzero.Dsize; ++iD) {
+
+      bool passDSelection = tightsel(iD, MDzero) && MDzero.Dpt[iD] >= MinDzeroPT && MDzero.Dpt[iD] <= MaxDzeroPT &&
+                            MDzero.Dy[iD] >= MinDzeroY && MDzero.Dy[iD] <= MaxDzeroY;
+      if (ApplyDSelection && !passDSelection)
+        continue;
+
+      fprintf(outfile,
+              "[D %d] "
+              "Dpt %f Dy %f Dmass %f\n"
+              "Dtrk1Pt %f Dtrk2Pt %f\n"
+              "Dchi2cl %f DsvpvDistance %f DsvpvDisErr %f\n"
+              "Dalpha %f DsvpvDistance_2D %f DsvpvDisErr_2D %f\n"
+              "Ddtheta %f\n",
+              iD, MDzero.Dpt[iD], MDzero.Dy[iD], MDzero.Dmass[iD], MDzero.Dtrk1Pt[iD], MDzero.Dtrk2Pt[iD],
+              MDzero.Dchi2cl[iD], MDzero.DsvpvDistance[iD], MDzero.DsvpvDisErr[iD], MDzero.Dalpha[iD],
+              MDzero.DsvpvDistance_2D[iD], MDzero.DsvpvDisErr_2D[iD], MDzero.Ddtheta[iD]);
+
+      v.FillRecoDInfo(MDzero.Dpt[iD], MDzero.Dy[iD], MDzero.Dmass[iD], MDzero.Dtrk1Pt[iD], MDzero.Dtrk2Pt[iD],
+                      MDzero.Dchi2cl[iD], MDzero.DsvpvDistance[iD], MDzero.DsvpvDisErr[iD], MDzero.Dalpha[iD],
+                      MDzero.DsvpvDistance_2D[iD], MDzero.DsvpvDisErr_2D[iD], MDzero.Ddtheta[iD]);
+
+      if (!IsData) {
+        bool isSignalGenMatched = MDzero.Dgen[iD] == 23333 && MDzero.Dgenpt[iD] > 0.;
+        bool isPromptGenMatched = isSignalGenMatched && (MDzero.DgenBAncestorpdgId[iD] == 0);
+        bool isFeeddownGenMatched =
+            isSignalGenMatched && ((MDzero.DgenBAncestorpdgId[iD] >= 500 && MDzero.DgenBAncestorpdgId[iD] < 600) ||
+                                   (MDzero.DgenBAncestorpdgId[iD] > -600 && MDzero.DgenBAncestorpdgId[iD] <= -500));
+
+        fprintf(outfile, "Dgen %d DisSignalCalc %o DisSignalCalcPrompt %o DisSignalCalcFeeddown %o\n", MDzero.Dgen[iD],
+                isSignalGenMatched, isPromptGenMatched, isFeeddownGenMatched);
+
+        v.FillRecoDGenMatchedInfo(MDzero.Dgen[iD], (int)isSignalGenMatched, (int)isPromptGenMatched,
+                                  (int)isFeeddownGenMatched);
+      }
+    }
+
+    if (!IsData) {
+      for (int iG = 0; iG < MDzeroGen.Gsize; ++iG) {
+        bool isSignalGen = (MDzeroGen.GisSignal[iG] == 1 || MDzeroGen.GisSignal[iG] == 2) && MDzeroGen.Gpt[iG] > 0.;
+        bool isPromptGen = isSignalGen && MDzeroGen.GBAncestorpdgId[iG] == 0;
+        bool isFeeddownGen =
+            isSignalGen && ((MDzeroGen.GBAncestorpdgId[iG] >= 500 && MDzeroGen.GBAncestorpdgId[iG] < 600) ||
+                            (MDzeroGen.GBAncestorpdgId[iG] > -600 && MDzeroGen.GBAncestorpdgId[iG] <= -500));
+
+        fprintf(outfile,
+                "[G %d] "
+                "Gpt %f Gy %f\n"
+                "GisSignalCalc %d GisSignalCalcPrompt %d GisSignalCalcFeeddown %d\n",
+                iG, MDzeroGen.Gpt[iG], MDzeroGen.Gy[iG], isSignalGen, isPromptGen, isFeeddownGen);
+
+        v.FillGenDInfo(MDzeroGen.Gpt[iG], MDzeroGen.Gy[iG], isSignalGen, isPromptGen, isFeeddownGen);
+      }
+    }
+  }
+  v.Write();
+
+  fclose(outfile);
+
+  return 0;
+}
+
+// copy from main analysis
+void calcRapidityGapsInput(std::vector<float> *pfE, std::vector<float> *pfPt, std::vector<float> *pfEta,
+                           std::vector<int> *pfId, int &nPFHFMinus_, int &nPFHFPlus_) {
+  // initialize counters
+  nPFHFMinus_ = 0;
+  nPFHFPlus_ = 0;
+
+  // defining the constant
+  const static float pfEMinMinus_ = 8.6;
+  const static float pfEMinPlus_ = 9.2;
+  const static float pfAEtaMin_ = 3.0;
+  const static float pfAEtaMax_ = 5.2;
+  const static std::vector<Int_t> pfValidId_ = {6, 7};
+  // float minPfPt monitoring for protection
+  float minPfPtFound_ = 999999.0;
+  float minPfAEtaFound_ = -1.0;
+  float maxPfAEtaFound_ = -1.0;
+
+  for (unsigned int pI = 0; pI < pfE->size(); ++pI) {
+    // For protection check/record min
+    if (pfPt->at(pI) < minPfPtFound_)
+      minPfPtFound_ = pfPt->at(pI);
+
+    float aEta = TMath::Abs(pfEta->at(pI));
+
+    // For protection check/record max
+    if (aEta > maxPfAEtaFound_)
+      maxPfAEtaFound_ = aEta;
+    if (aEta < minPfAEtaFound_)
+      minPfAEtaFound_ = aEta;
+
+    // Apply kin. cuts
+    // Eta cuts
+    if (aEta < pfAEtaMin_)
+      continue;
+    if (aEta >= pfAEtaMax_)
+      continue;
+    // Eta gated pfEMin cuts
+    if (pfEta->at(pI) < 0.0) { // first minus
+      if (pfE->at(pI) < pfEMinMinus_)
+        continue;
+    } else { // Now plus
+      if (pfE->at(pI) < pfEMinPlus_)
+        continue;
+    }
+
+    // Apply ID cut
+    bool idIsGood = false;
+    for (auto const &goodId : pfValidId_) {
+      if (pfId->at(pI) == goodId) {
+        idIsGood = true;
+        break;
+      }
+    }
+    if (!idIsGood)
+      continue;
+
+    // After all cuts passed, increment counter
+    if (pfEta->at(pI) < 0.0)
+      ++nPFHFMinus_;
+    else
+      ++nPFHFPlus_;
+  }
+
+  return;
+}
+
+bool tightsel(int j, DzeroTreeMessenger &MDzero, std::string varySel) {
+  using floatVector2D = std::vector<std::vector<float>>;
+
+  // Nominal cut values
+  const static floatVector2D DsvpvSigCutValue = {                                // {3.5, 3.5, 3.5, 3.5, 3.5, 3.5},
+                                                 {2.5, 2.5, 2.5, 2.5, 2.5, 2.5}, // check with gm
+                                                 {3.5, 3.5, 3.5, 3.5, 3.5, 3.5},
+                                                 {3.5, 3.5, 3.5, 3.5, 3.5, 3.5}};
+  const static floatVector2D Dchi2clCutValue = {
+      {0.1, 0.1, 0.1, 0.1, 0.1, 0.1}, {0.1, 0.1, 0.1, 0.1, 0.1, 0.1}, {0.1, 0.1, 0.1, 0.1, 0.1, 0.1}};
+  const static floatVector2D DalphaCutValue = {
+      {0.2, 0.2, 0.4, 0.4, 0.2, 0.2}, {0.25, 0.25, 0.35, 0.35, 0.25, 0.25}, {0.25, 0.25, 0.4, 0.4, 0.25, 0.25}};
+  const static floatVector2D DdthetaCutValue = {
+      {0.3, 0.3, 0.5, 0.5, 0.3, 0.3}, {0.3, 0.3, 0.3, 0.3, 0.3, 0.3}, {0.3, 0.3, 0.3, 0.3, 0.3, 0.3}};
+  const static floatVector2D Dtrk1PtCutValue = {
+      {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}, {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}, {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}};
+  const static floatVector2D Dtrk2PtCutValue = {
+      {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}, {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}, {1.0, 1.0, 1.0, 1.0, 1.0, 1.0}};
+  static const int nPt = 3;
+  static const int nY = 6;
+  float ptBins[nPt + 1] = {2.0, 5.0, 8.0, 999.0};
+  float yBins[nY + 1] = {-2.4, -2.0, -1.0, 0.0, 1.0, 2.0, 2.4};
+  TH2D Dtrk1PtCut("Dtrk1PtCut", "Dtrk1PtCut", nPt, ptBins, nY, yBins);
+  TH2D Dtrk2PtCut("Dtrk2PtCut", "Dtrk2PtCut", nPt, ptBins, nY, yBins);
+  TH2D DsvpvSigCut("DsvpvSigCut", "DsvpvSigCut", nPt, ptBins, nY, yBins);
+  TH2D DalphaCut("DalphaCut", "DalphaCut", nPt, ptBins, nY, yBins);
+  TH2D DdthetaCut("DdthetaCut", "DdthetaCut", nPt, ptBins, nY, yBins);
+  TH2D Dchi2clCut("Dchi2clCut", "Dchi2clCut", nPt, ptBins, nY, yBins);
+  TH2D Dtrk1PtVariedCut("Dtrk1PtVariedCut", "Dtrk1PtVariedCut", nPt, ptBins, nY, yBins);
+  TH2D Dtrk2PtVariedCut("Dtrk2PtVariedCut", "Dtrk2PtVariedCut", nPt, ptBins, nY, yBins);
+  TH2D DsvpvSigVariedCut("DsvpvSigVariedCut", "DsvpvSigVariedCut", nPt, ptBins, nY, yBins);
+  TH2D DalphaVariedCut("DalphaVariedCut", "DalphaVariedCut", nPt, ptBins, nY, yBins);
+  TH2D DdthetaVariedCut("DdthetaVariedCut", "DdthetaVariedCut", nPt, ptBins, nY, yBins);
+  TH2D Dchi2clVariedCut("Dchi2clVariedCut", "Dchi2clVariedCut", nPt, ptBins, nY, yBins);
+  for (int iPt = 0; iPt < nPt; ++iPt) {
+    for (int iY = 0; iY < nY; ++iY) {
+      DsvpvSigCut.SetBinContent(iPt + 1, iY + 1, DsvpvSigCutValue[iPt][iY]);
+      DalphaCut.SetBinContent(iPt + 1, iY + 1, DalphaCutValue[iPt][iY]);
+      DdthetaCut.SetBinContent(iPt + 1, iY + 1, DdthetaCutValue[iPt][iY]);
+      Dchi2clCut.SetBinContent(iPt + 1, iY + 1, Dchi2clCutValue[iPt][iY]);
+      Dtrk1PtCut.SetBinContent(iPt + 1, iY + 1, Dtrk1PtCutValue[iPt][iY]);
+      Dtrk2PtCut.SetBinContent(iPt + 1, iY + 1, Dtrk2PtCutValue[iPt][iY]);
+    }
+  }
+
+  // static bool init = false;
+  // if (!init)
+  // {
+  //   std::cout << __PRETTY_FUNCTION__ << ": Cuts updated as follows " << std::endl;
+  //   std::cout << " DsvpvSigCut Print" << std::endl;
+  //   DsvpvSigCut.Print("ALL");
+  //   std::cout << " DalphaCut Print" << std::endl;
+  //   DalphaCut.Print("ALL");
+  //   std::cout << " DdthetaCut Print" << std::endl;
+  //   DdthetaCut.Print("ALL");
+  //   std::cout << " Dchi2clCut Print" << std::endl;
+  //   Dchi2clCut.Print("ALL");
+  //   std::cout << " Dtrk1PtCut Print" << std::endl;
+  //   Dtrk1PtCut.Print("ALL");
+  //   std::cout << " Dtrk2PtCut Print" << std::endl;
+  //   Dtrk2PtCut.Print("ALL");
+
+  //   init = true;
+  // }
+
+  // IF YOU CHANGE VARIABLES USED BY THIS FUNCTION,
+  // PLEASE EDIT tightselVarHI_, tightselVarPP_ APPROPRIATELY!
+  // Protections for cut
+  //  if(!tightselVarsFound_) return cutProtectionMsg(__PRETTY_FUNCTION__);
+
+  // Valid variations
+  std::vector<std::string> validVaryVect = {"SVPV", "alpha", "chi2cl"};
+  // Test if a variation requested is valid
+  if (varySel.size() != 0) {
+    bool validVaryBool = false;
+    for (unsigned int vI = 0; vI < validVaryVect.size(); ++vI) {
+      if (validVaryVect[vI] == varySel) {
+        validVaryBool = true;
+        break;
+      }
+    }
+
+    if (!validVaryBool) {
+      std::cout << __PRETTY_FUNCTION__ << " ERROR: Requested variation '" << varySel
+                << "' is not valid. Check, returning false always" << std::endl;
+      return false;
+    }
+  }
+
+  float Dpt = MDzero.Dpt[j];
+  float Dy = MDzero.Dy[j];
+  int bin = DalphaCut.FindBin(Dpt, Dy);
+
+  Double_t DsvpvSigCutLocal = DsvpvSigCut[bin];
+  Double_t DalphaCutLocal = DalphaCut[bin];
+  Double_t DdthetaCutLocal = DdthetaCut[bin];
+  Double_t Dchi2clCutLocal = Dchi2clCut[bin];
+  // if(varySel == "SVPV") {
+  //   DsvpvSigCutLocal = DsvpvSigVariedCut[bin];
+  // }
+  // if(varySel == "alpha") {
+  //   DalphaCutLocal = DalphaVariedCut[bin];
+  //   DdthetaCutLocal = DdthetaVariedCut[bin];
+  // }
+  // if(varySel == "chi2cl") {
+  //   Dchi2clCutLocal = Dchi2clVariedCut[bin];
+  // }
+
+  bool cut = MDzero.DsvpvDistance[j] / MDzero.DsvpvDisErr[j] > DsvpvSigCutLocal;
+  cut = cut && MDzero.Dalpha[j] < DalphaCutLocal;
+  cut = cut && MDzero.Ddtheta[j] < DdthetaCutLocal;
+  cut = cut && MDzero.Dchi2cl[j] > Dchi2clCutLocal;
+  // if(varySel == "alpha") {
+  //   std::cout << bvf_["Dalpha"][j] << " <? " << DalphaCutLocal << std::endl;
+  // }
+
+  // if(ishi_) cut = true; // wtf is this
+  return cut;
+}

--- a/MainAnalysis/20241110_SkimValidation/README.md
+++ b/MainAnalysis/20241110_SkimValidation/README.md
@@ -1,0 +1,23 @@
+### Skim Format Validation
+- Usage:
+	```bash
+	# validate the old and new skims (data) with event selections
+	make ValidateData
+	# validate the old and new skims (data) with event selections + D selections
+	make ValidateDataWDsel
+	# validate the old and new skims (MC) with event selections
+	make ValidateMC
+	# validate the old and new skims (MC) with event selections + D selections
+	make ValidateMCWDsel
+	```
+	- Note that the above makefile rule will create an out/DumpSkim.diff file and display the content with `less out/DumpSkim.diff`.
+	If the file is empty that means things are aligned btw the two skims, and one can quit 'less out/DumpSkims.diff' by entering 'q'.
+
+- Macro:
+	- `DumpNewSkim.cpp`, `DumpOldSkim.cpp`: print and store histograms for comparison
+
+	- `Validate.cpp`: comparison btw two dump output root files
+
+- `ValidateHist.h`:
+	Defining histograms for validation
+

--- a/MainAnalysis/20241110_SkimValidation/Validate.cpp
+++ b/MainAnalysis/20241110_SkimValidation/Validate.cpp
@@ -1,0 +1,223 @@
+/* + Descriptions:
+ *		Macro to compare root files create in either DumpNewSkim or DumpOldSkim
+ * + Output:
+ * 		+ Will create a summary pdf for the histograms overlay and ratio
+ * 		+ Calculate and print chisq for two skims, chisq=0 means the two are exactly the same
+ */
+#include <string>
+
+#include "CommandLine.h"
+
+#include "TCanvas.h"
+#include "TLegend.h"
+#include "TLine.h"
+#include "TMath.h"
+#include "TStyle.h"
+#include "ValidateHist.h"
+
+using namespace std;
+
+void formatLegend(TLegend *leg, double textsize = 27) {
+  leg->SetBorderSize(0);
+  leg->SetTextFont(43);
+  leg->SetTextSize(textsize);
+  leg->SetFillStyle(0);
+  leg->SetFillColor(0);
+  leg->SetLineColor(0);
+}
+
+template <class T>
+void sethempty(T *hempty, Float_t xoffset = 0, Float_t yoffset = 0, Float_t xsize = 1, Float_t ysize = 1) {
+  hempty->GetXaxis()->CenterTitle();
+  hempty->GetYaxis()->CenterTitle();
+  hempty->GetXaxis()->SetTitleOffset(1.10 + xoffset);
+  hempty->GetYaxis()->SetTitleOffset(1.30 + yoffset);
+  hempty->GetXaxis()->SetTitleSize(0.05 * xsize);
+  hempty->GetYaxis()->SetTitleSize(0.05 * ysize);
+  hempty->GetXaxis()->SetTitleFont(42);
+  hempty->GetYaxis()->SetTitleFont(42);
+  hempty->GetXaxis()->SetLabelFont(42);
+  hempty->GetYaxis()->SetLabelFont(42);
+  hempty->GetXaxis()->SetLabelSize(0.045 * xsize);
+  hempty->GetYaxis()->SetLabelSize(0.045 * ysize);
+  hempty->SetStats(0);
+}
+
+void doRatio(TH1D *ref, const std::vector<TH1D *> &cmp_vec, TPad *motherPad, TLegend *leg,
+             string ratioYAxisName = "Ratio", bool logy = false, string curvePlotStyle = "h", double padSplit = 0.3) {
+  int numBinsX = ref->GetNbinsX();
+  double xMin = ref->GetXaxis()->GetXmin();
+  double xMax = ref->GetXaxis()->GetXmax();
+
+  sethempty(ref, 0, padSplit / 3);
+
+  TH1D *hempty_ratio =
+      new TH1D(Form("hempty_ratio_%s", ref->GetName()),
+               Form(";%s;%s", ref->GetXaxis()->GetTitle(), ratioYAxisName.c_str()), numBinsX, xMin, xMax);
+
+  sethempty(hempty_ratio, 0, -2 * padSplit, 0.1, 0.1);
+  hempty_ratio->GetYaxis()->SetNdivisions(505);
+  hempty_ratio->GetYaxis()->SetLabelSize(0.1);
+  hempty_ratio->GetXaxis()->SetLabelSize(0.1);
+
+  hempty_ratio->SetTitle("");
+  hempty_ratio->GetXaxis()->SetTitleSize(hempty_ratio->GetXaxis()->GetTitleSize() * 20.0);
+  hempty_ratio->GetXaxis()->SetLabelSize(hempty_ratio->GetXaxis()->GetLabelSize());
+  hempty_ratio->GetYaxis()->SetTitleSize(hempty_ratio->GetYaxis()->GetTitleSize() * 20.0);
+  hempty_ratio->GetYaxis()->SetLabelSize(hempty_ratio->GetYaxis()->GetLabelSize());
+  hempty_ratio->GetXaxis()->SetTitleOffset(0); // hempty_ratio->GetXaxis()->GetTitleOffset());
+  hempty_ratio->GetYaxis()->SetTitleOffset(0); // hempty_ratio->GetYaxis()->GetTitleOffset() * 0.42);
+  hempty_ratio->GetYaxis()->SetNdivisions(205);
+
+  // hempty_ratio->GetXaxis()->SetRangeUser(0,xRangeMax);
+  hempty_ratio->GetYaxis()->SetRangeUser(0.95, 1.05);
+
+  motherPad->cd();
+  motherPad->Divide(1, 2, 0, 0);
+  TPad *pad1 = (TPad *)motherPad->GetPad(1);
+  TPad *pad2 = (TPad *)motherPad->GetPad(2);
+  pad1->SetPad(0.0, 0.30, 1.0, 1.0);
+  pad2->SetPad(0.0, 0.0, 1.0, 0.30);
+  motherPad->SetLogy();
+  motherPad->SetTickx(1);
+  motherPad->SetTicky(1);
+
+  pad1->SetTopMargin(0.1);
+  pad1->SetBottomMargin(0);
+  pad1->SetLeftMargin(0.15);
+  pad1->SetRightMargin(0.05);
+  if (logy)
+    pad1->SetLogy();
+  pad1->SetTickx(1);
+  pad1->SetTicky(1);
+  pad1->Draw();
+  pad2->SetTopMargin(0);
+  pad2->SetBottomMargin(0.3);
+  pad2->SetLeftMargin(0.15);
+  pad2->SetRightMargin(0.05);
+  pad2->SetTickx(1);
+  pad2->SetTicky(1);
+  pad2->Draw();
+
+  pad1->cd();
+
+  ref->DrawClone(curvePlotStyle.c_str());
+  for (auto cmp : cmp_vec) {
+    cmp->DrawClone(Form("%s same", curvePlotStyle.c_str()));
+  }
+  if (leg)
+    leg->DrawClone("same");
+
+  pad2->cd();
+  hempty_ratio->DrawClone();
+  for (auto cmp : cmp_vec) {
+    TH1D *hratio = (TH1D *)cmp->Clone(Form("hratio_%s", cmp->GetName()));
+    hratio->Divide(ref);
+    hratio->DrawClone("ple same");
+  }
+
+  TLine *line = new TLine(xMin, 1, xMax, 1);
+  line->SetLineStyle(2);
+  line->SetLineColor(kGray + 2);
+  line->DrawClone("same");
+
+  delete line;
+  delete hempty_ratio;
+}
+
+double getChiSquare(TH1D *h1, TH1D *h2) {
+  // Check that the histograms have the same binning
+  if (h1->GetNbinsX() != h2->GetNbinsX()) {
+    std::cerr << "Histograms have different binning." << std::endl;
+    return -1;
+  }
+
+  double chiSquare = 0.;
+  for (int i = 1; i <= h1->GetNbinsX(); ++i) {
+    double content1 = h1->GetBinContent(i);
+    double content2 = h2->GetBinContent(i);
+
+    double error1 = h1->GetBinError(i);
+    double error2 = h2->GetBinError(i);
+
+    // Calculate the denominator (combined variance from two independent random variables)
+    double denominator = error1 * error1 + error2 * error2;
+
+    // Add the contribution to the chi-square, checking for zero denominator
+    if (denominator != 0) {
+      chiSquare += (content1 - content2) * (content1 - content2) / denominator;
+    } else {
+      if (content1 != 0 || content2 != 0)
+        std::cerr << "Warning: Zero denominator in bin " << i << std::endl;
+    }
+  }
+  return (chiSquare);
+}
+
+int main(int argc, char *argv[]) {
+  CommandLine CL(argc, argv);
+
+  string VHName1 = CL.Get("Input1");
+  string VHName2 = CL.Get("Input2");
+  string LegendName1 = CL.Get("LegendName1");
+  string LegendName2 = CL.Get("LegendName2");
+  string PlotName = CL.Get("PlotName");
+
+  ValidateHist v1(VHName1, "r");
+  ValidateHist v2(VHName2, "r");
+
+  vector<string> histNameToPlot;
+  for (const auto &[key, hist1] : v1.histDict) {
+    if (!v2.histDict[key]) {
+      printf("[Warning] Couldn't find hist (%s) in %s. Skipping the comparison.\n", key.c_str(), VHName2.c_str());
+      return 1;
+    }
+    TH1D *hist2 = v2.histDict[key];
+    if (hist1->GetEntries() == 0 && hist2->GetEntries() == 0)
+      continue;
+
+    histNameToPlot.push_back(key);
+  }
+
+  int _nHist = histNameToPlot.size();
+  int _nCol = 5;
+  int _nRow = TMath::Ceil(_nHist / ((float)_nCol));
+  TCanvas *canv = new TCanvas("canv", "", 600 * _nCol, 600 * _nRow);
+  canv->Divide(_nCol, _nRow);
+
+  TLegend *legend = new TLegend(0.6, 0.7, 0.8, 0.9);
+
+  gStyle->SetOptStat(0);
+
+  for (int iPlot = 0; iPlot < histNameToPlot.size(); ++iPlot) {
+    string key = histNameToPlot[iPlot];
+    TH1D *hist1 = v1.histDict[key];
+    TH1D *hist2 = v2.histDict[key];
+
+    hist1->SetLineColor(kBlue);
+    // hist1->SetLineWidth(2);
+
+    hist2->SetFillColorAlpha(kRed, 0.3);
+    hist2->SetLineColorAlpha(kRed, 0.3);
+
+    if (iPlot == 0) {
+      legend->AddEntry(hist1, LegendName1.c_str(), "le");
+      legend->AddEntry(hist2, LegendName2.c_str(), "lf");
+      formatLegend(legend, 21);
+    }
+
+    double chisq = getChiSquare(hist1, hist2);
+    printf("%s: chisq=%f\n", key.c_str(), chisq);
+
+    doRatio(hist2, {hist1}, (TPad *)canv->GetPad(iPlot + 1), (iPlot == 0) ? legend : nullptr,
+            Form("%s/%s", LegendName1.c_str(), LegendName2.c_str()),
+            (key == "VX" || key == "VXError" || key == "VY" || key == "VYError" || key == "VZ" || key == "VZError" ||
+             key == "DsvpvDistance" || key == "DsvpvDisErr" || key == "DsvpvDistance_2D" || key == "DsvpvDisErr_2D")
+                ? true
+                : false);
+  }
+
+  canv->SaveAs(PlotName.c_str());
+
+  return 0;
+}

--- a/MainAnalysis/20241110_SkimValidation/ValidateHist.h
+++ b/MainAnalysis/20241110_SkimValidation/ValidateHist.h
@@ -1,0 +1,337 @@
+#ifndef _VALIDATEHIST_H_
+#define _VALIDATEHIST_H_
+
+/* + Descriptions:
+ *		Class of reading and writing the root files for validation use
+ */
+
+#include <iostream>
+#include <map>
+#include <string>
+
+#include "TFile.h"
+#include "TH1D.h"
+
+using namespace std;
+
+class ValidateHist {
+public:
+  ValidateHist(string filename,
+               string mode); // read mode 	= "r", "READ"
+                             // write mode = "recreate", "RECREATE"
+  ~ValidateHist();
+
+  void FillEventInfo(int _Run, int _Lumi, int _Event, float _VX, float _VY, float _VZ, float _VXError, float _VYError,
+                     float _VZError, int _Dsize, int _Gsize = -999) {
+    h_Run->Fill(_Run);
+    h_Lumi->Fill(_Lumi);
+    h_Event->Fill(_Event);
+    h_VX->Fill(_VX);
+    h_VY->Fill(_VY);
+    h_VZ->Fill(_VZ);
+    h_VXError->Fill(_VXError);
+    h_VYError->Fill(_VYError);
+    h_VZError->Fill(_VZError);
+    h_Dsize->Fill(_Dsize);
+    if (_Gsize > 0)
+      h_Gsize->Fill(_Gsize);
+  };
+
+  void FillEventSelectionInfo(int _isL1ZDCOr, int _isL1ZDCXORJet8, int _selectedBkgFilter, int _selectedVtxFilter,
+                              int _gammaN, int _Ngamma) {
+    h_isL1ZDCOr->Fill(_isL1ZDCOr);
+    h_isL1ZDCXORJet8->Fill(_isL1ZDCXORJet8);
+    h_selectedBkgFilter->Fill(_selectedBkgFilter);
+    h_selectedVtxFilter->Fill(_selectedVtxFilter);
+    h_gammaN->Fill(_gammaN);
+    h_Ngamma->Fill(_Ngamma);
+  };
+
+  void FillRecoDInfo(float _Dpt, float _Dy, float _Dmass, float _Dtrk1Pt, float _Dtrk2Pt, float _Dchi2cl,
+                     float _DsvpvDistance, float _DsvpvDisErr, float _Dalpha, float _DsvpvDistance_2D,
+                     float _DsvpvDisErr_2D, float _Ddtheta) {
+    h_Dpt->Fill(_Dpt);
+    h_Dy->Fill(_Dy);
+    h_Dmass->Fill(_Dmass);
+    h_Dtrk1Pt->Fill(_Dtrk1Pt);
+    h_Dtrk2Pt->Fill(_Dtrk2Pt);
+    h_Dchi2cl->Fill(_Dchi2cl);
+    h_DsvpvDistance->Fill(_DsvpvDistance);
+    h_DsvpvDisErr->Fill(_DsvpvDisErr);
+    h_Dalpha->Fill(_Dalpha);
+    h_DsvpvDistance_2D->Fill(_DsvpvDistance_2D);
+    h_DsvpvDisErr_2D->Fill(_DsvpvDisErr_2D);
+    h_Ddtheta->Fill(_Ddtheta);
+  };
+
+  void FillRecoDGenMatchedInfo(float _Dgen, float _DisSignalCalc, float _DisSignalCalcPrompt,
+                               float _DisSignalCalcFeeddown) {
+    h_Dgen->Fill(_Dgen);
+    h_DisSignalCalc->Fill(_DisSignalCalc);
+    h_DisSignalCalcPrompt->Fill(_DisSignalCalcPrompt);
+    h_DisSignalCalcFeeddown->Fill(_DisSignalCalcFeeddown);
+  };
+
+  void FillGenDInfo(float _Gpt, float _Gy, float _GisSignalCalc, float _GisSignalCalcPrompt,
+                    float _GisSignalCalcFeeddown) {
+    h_Gpt->Fill(_Gpt);
+    h_Gy->Fill(_Gy);
+    h_GisSignalCalc->Fill(_GisSignalCalc);
+    h_GisSignalCalcPrompt->Fill(_GisSignalCalcPrompt);
+    h_GisSignalCalcFeeddown->Fill(_GisSignalCalcFeeddown);
+  };
+  void Write();
+
+  TFile *output;
+
+  map<string, TH1D *> histDict;
+
+private:
+  // event by event info
+  TH1D *h_Run;
+  TH1D *h_Lumi;
+  TH1D *h_Event;
+
+  TH1D *h_isL1ZDCOr;
+  TH1D *h_isL1ZDCXORJet8;
+  TH1D *h_selectedBkgFilter;
+  TH1D *h_selectedVtxFilter;
+  TH1D *h_gammaN;
+  TH1D *h_Ngamma;
+
+  TH1D *h_VX;
+  TH1D *h_VY;
+  TH1D *h_VZ;
+  TH1D *h_VXError;
+  TH1D *h_VYError;
+  TH1D *h_VZError;
+
+  TH1D *h_Dsize;
+
+  // D candidates
+  TH1D *h_Dpt;
+  TH1D *h_Dy;
+  TH1D *h_Dmass;
+  TH1D *h_Dtrk1Pt;
+  TH1D *h_Dtrk2Pt;
+  TH1D *h_Dchi2cl;
+  TH1D *h_DsvpvDistance;
+  TH1D *h_DsvpvDisErr;
+  TH1D *h_Dalpha;
+  TH1D *h_DsvpvDistance_2D;
+  TH1D *h_DsvpvDisErr_2D;
+  TH1D *h_Ddtheta;
+
+  // MC only quantities
+  TH1D *h_Dgen;
+  TH1D *h_DisSignalCalc;
+  TH1D *h_DisSignalCalcPrompt;
+  TH1D *h_DisSignalCalcFeeddown;
+
+  TH1D *h_Gsize;
+  TH1D *h_Gpt;
+  TH1D *h_Gy;
+  TH1D *h_GisSignalCalc;
+  TH1D *h_GisSignalCalcPrompt;
+  TH1D *h_GisSignalCalcFeeddown;
+};
+
+ValidateHist::ValidateHist(string filename,
+                           string mode) // read mode 	= "r", "READ", ""
+                                        // write mode = "recreate", "RECREATE"
+{
+  output = new TFile(filename.c_str(), mode.c_str());
+
+  if (mode == "r" || mode == "READ" || mode == "") {
+    h_Run = (TH1D *)output->Get("h_Run");
+    histDict["Run"] = h_Run;
+    h_Lumi = (TH1D *)output->Get("h_Lumi");
+    histDict["Lumi"] = h_Lumi;
+    h_Event = (TH1D *)output->Get("h_Event");
+    histDict["Event"] = h_Event;
+
+    h_isL1ZDCOr = (TH1D *)output->Get("h_isL1ZDCOr");
+    histDict["isL1ZDCOr"] = h_isL1ZDCOr;
+    h_isL1ZDCXORJet8 = (TH1D *)output->Get("h_isL1ZDCXORJet8");
+    histDict["isL1ZDCXORJet8"] = h_isL1ZDCXORJet8;
+    h_selectedBkgFilter = (TH1D *)output->Get("h_selectedBkgFilter");
+    histDict["selectedBkgFilter"] = h_selectedBkgFilter;
+    h_selectedVtxFilter = (TH1D *)output->Get("h_selectedVtxFilter");
+    histDict["selectedVtxFilter"] = h_selectedVtxFilter;
+    h_gammaN = (TH1D *)output->Get("h_gammaN");
+    histDict["gammaN"] = h_gammaN;
+    h_Ngamma = (TH1D *)output->Get("h_Ngamma");
+    histDict["Ngamma"] = h_Ngamma;
+
+    h_VX = (TH1D *)output->Get("h_VX");
+    histDict["VX"] = h_VX;
+    h_VY = (TH1D *)output->Get("h_VY");
+    histDict["VY"] = h_VY;
+    h_VZ = (TH1D *)output->Get("h_VZ");
+    histDict["VZ"] = h_VZ;
+    h_VXError = (TH1D *)output->Get("h_VXError");
+    histDict["VXError"] = h_VXError;
+    h_VYError = (TH1D *)output->Get("h_VYError");
+    histDict["VYError"] = h_VYError;
+    h_VZError = (TH1D *)output->Get("h_VZError");
+    histDict["VZError"] = h_VZError;
+
+    h_Dsize = (TH1D *)output->Get("h_Dsize");
+    histDict["Dsize"] = h_Dsize;
+
+    h_Dpt = (TH1D *)output->Get("h_Dpt");
+    histDict["Dpt"] = h_Dpt;
+    h_Dy = (TH1D *)output->Get("h_Dy");
+    histDict["Dy"] = h_Dy;
+    h_Dmass = (TH1D *)output->Get("h_Dmass");
+    histDict["Dmass"] = h_Dmass;
+    h_Dtrk1Pt = (TH1D *)output->Get("h_Dtrk1Pt");
+    histDict["Dtrk1Pt"] = h_Dtrk1Pt;
+    h_Dtrk2Pt = (TH1D *)output->Get("h_Dtrk2Pt");
+    histDict["Dtrk2Pt"] = h_Dtrk2Pt;
+    h_Dchi2cl = (TH1D *)output->Get("h_Dchi2cl");
+    histDict["Dchi2cl"] = h_Dchi2cl;
+    h_DsvpvDistance = (TH1D *)output->Get("h_DsvpvDistance");
+    histDict["DsvpvDistance"] = h_DsvpvDistance;
+    h_DsvpvDisErr = (TH1D *)output->Get("h_DsvpvDisErr");
+    histDict["DsvpvDisErr"] = h_DsvpvDisErr;
+    h_Dalpha = (TH1D *)output->Get("h_Dalpha");
+    histDict["Dalpha"] = h_Dalpha;
+    h_DsvpvDistance_2D = (TH1D *)output->Get("h_DsvpvDistance_2D");
+    histDict["DsvpvDistance_2D"] = h_DsvpvDistance_2D;
+    h_DsvpvDisErr_2D = (TH1D *)output->Get("h_DsvpvDisErr_2D");
+    histDict["DsvpvDisErr_2D"] = h_DsvpvDisErr_2D;
+    h_Ddtheta = (TH1D *)output->Get("h_Ddtheta");
+    histDict["Ddtheta"] = h_Ddtheta;
+
+    h_Dgen = (TH1D *)output->Get("h_Dgen");
+    histDict["Dgen"] = h_Dgen;
+    h_DisSignalCalc = (TH1D *)output->Get("h_DisSignalCalc");
+    histDict["DisSignalCalc"] = h_DisSignalCalc;
+    h_DisSignalCalcPrompt = (TH1D *)output->Get("h_DisSignalCalcPrompt");
+    histDict["DisSignalCalcPrompt"] = h_DisSignalCalcPrompt;
+    h_DisSignalCalcFeeddown = (TH1D *)output->Get("h_DisSignalCalcFeeddown");
+    histDict["DisSignalCalcFeeddown"] = h_DisSignalCalcFeeddown;
+
+    h_Gsize = (TH1D *)output->Get("h_Gsize");
+    histDict["Gsize"] = h_Gsize;
+    h_Gpt = (TH1D *)output->Get("h_Gpt");
+    histDict["Gpt"] = h_Gpt;
+    h_Gy = (TH1D *)output->Get("h_Gy");
+    histDict["Gy"] = h_Gy;
+    h_GisSignalCalc = (TH1D *)output->Get("h_GisSignalCalc");
+    histDict["GisSignalCalc"] = h_GisSignalCalc;
+    h_GisSignalCalcPrompt = (TH1D *)output->Get("h_GisSignalCalcPrompt");
+    histDict["GisSignalCalcPrompt"] = h_GisSignalCalcPrompt;
+    h_GisSignalCalcFeeddown = (TH1D *)output->Get("h_GisSignalCalcFeeddown");
+    histDict["GisSignalCalcFeeddown"] = h_GisSignalCalcFeeddown;
+  } else if (mode == "recreate" || mode == "RECREATE") {
+    h_Run = new TH1D("h_Run", "; Run; Count", 1000, 0, 400000);
+    histDict["Run"] = h_Run;
+    h_Lumi = new TH1D("h_Lumi", "; Lumi; Count", 1000, 0, 1000);
+    histDict["Lumi"] = h_Lumi;
+    h_Event = new TH1D("h_Event", "; Event; Count", 1000, 0, 1.30e9);
+    histDict["Event"] = h_Event;
+
+    h_isL1ZDCOr = new TH1D("h_isL1ZDCOr", "; isL1ZDCOr; Count", 2, 0, 2);
+    histDict["isL1ZDCOr"] = h_isL1ZDCOr;
+    h_isL1ZDCXORJet8 = new TH1D("h_isL1ZDCXORJet8", "; isL1ZDCXORJet8; Count", 2, 0, 2);
+    histDict["isL1ZDCXORJet8"] = h_isL1ZDCXORJet8;
+    h_selectedBkgFilter = new TH1D("h_selectedBkgFilter", "; selectedBkgFilter; Count", 2, 0, 2);
+    histDict["selectedBkgFilter"] = h_selectedBkgFilter;
+    h_selectedVtxFilter = new TH1D("h_selectedVtxFilter", "; selectedVtxFilter; Count", 2, 0, 2);
+    histDict["selectedVtxFilter"] = h_selectedVtxFilter;
+    h_gammaN = new TH1D("h_gammaN", "; gammaN; Count", 2, 0, 2);
+    histDict["gammaN"] = h_gammaN;
+    h_Ngamma = new TH1D("h_Ngamma", "; Ngamma; Count", 2, 0, 2);
+    histDict["Ngamma"] = h_Ngamma;
+
+    h_VX = new TH1D("h_VX", "; VX; Count", 40, -0.5, 0.5);
+    histDict["VX"] = h_VX;
+    h_VY = new TH1D("h_VY", "; VY; Count", 40, -0.5, 0.5);
+    histDict["VY"] = h_VY;
+    h_VZ = new TH1D("h_VZ", "; VZ; Count", 40, -20, 20);
+    histDict["VZ"] = h_VZ;
+    h_VXError = new TH1D("h_VXError", "; VXError; Count", 40, 0, 0.1);
+    histDict["VXError"] = h_VXError;
+    h_VYError = new TH1D("h_VYError", "; VYError; Count", 40, 0, 0.1);
+    histDict["VYError"] = h_VYError;
+    h_VZError = new TH1D("h_VZError", "; VZError; Count", 40, 0, 0.5);
+    histDict["VZError"] = h_VZError;
+
+    h_Dsize = new TH1D("h_Dsize", "; Dsize; Count", 40, 0, 20);
+    histDict["Dsize"] = h_Dsize;
+
+    h_Dpt = new TH1D("h_Dpt", "; Dpt; Count", 40, 0, 10);
+    histDict["Dpt"] = h_Dpt;
+    h_Dy = new TH1D("h_Dy", "; Dy; Count", 40, -3, 3);
+    histDict["Dy"] = h_Dy;
+    h_Dmass = new TH1D("h_Dmass", "; Dmass; Count", 40, 1.5, 2.2);
+    histDict["Dmass"] = h_Dmass;
+    h_Dtrk1Pt = new TH1D("h_Dtrk1Pt", "; Dtrk1Pt; Count", 40, 0, 5);
+    histDict["Dtrk1Pt"] = h_Dtrk1Pt;
+    h_Dtrk2Pt = new TH1D("h_Dtrk2Pt", "; Dtrk2Pt; Count", 40, 0, 5);
+    histDict["Dtrk2Pt"] = h_Dtrk2Pt;
+    h_Dchi2cl = new TH1D("h_Dchi2cl", "; Dchi2cl; Count", 40, 0, 1);
+    histDict["Dchi2cl"] = h_Dchi2cl;
+    h_DsvpvDistance = new TH1D("h_DsvpvDistance", "; DsvpvDistance; Count", 40, 0, 40);
+    histDict["DsvpvDistance"] = h_DsvpvDistance;
+    h_DsvpvDisErr = new TH1D("h_DsvpvDisErr", "; DsvpvDisErr; Count", 40, 0, 5);
+    histDict["DsvpvDisErr"] = h_DsvpvDisErr;
+    h_Dalpha = new TH1D("h_Dalpha", "; Dalpha; Count", 40, 0, 0.55);
+    histDict["Dalpha"] = h_Dalpha;
+    h_DsvpvDistance_2D = new TH1D("h_DsvpvDistance_2D", "; DsvpvDistance_2D; Count", 40, 0, 15);
+    histDict["DsvpvDistance_2D"] = h_DsvpvDistance_2D;
+    h_DsvpvDisErr_2D = new TH1D("h_DsvpvDisErr_2D", "; DsvpvDisErr_2D; Count", 40, 0, 1.5);
+    histDict["DsvpvDisErr_2D"] = h_DsvpvDisErr_2D;
+    h_Ddtheta = new TH1D("h_Ddtheta", "; Ddtheta; Count", 40, 0, 3.5);
+    histDict["Ddtheta"] = h_Ddtheta;
+
+    h_Dgen = new TH1D("h_Dgen", "; Dgen; Count", 40, 0, 45e3);
+    histDict["Dgen"] = h_Dgen;
+    h_DisSignalCalc = new TH1D("h_DisSignalCalc", "; DisSignalCalc; Count", 2, 0, 2);
+    histDict["DisSignalCalc"] = h_DisSignalCalc;
+    h_DisSignalCalcPrompt = new TH1D("h_DisSignalCalcPrompt", "; DisSignalCalcPrompt; Count", 2, 0, 2);
+    histDict["DisSignalCalcPrompt"] = h_DisSignalCalcPrompt;
+    h_DisSignalCalcFeeddown = new TH1D("h_DisSignalCalcFeeddown", "; DisSignalCalcFeeddown; Count", 2, 0, 2);
+    histDict["DisSignalCalcFeeddown"] = h_DisSignalCalcFeeddown;
+
+    h_Gsize = new TH1D("h_Gsize", "; Gsize; Count", 10, 0, 10);
+    histDict["Gsize"] = h_Gsize;
+    h_Gpt = new TH1D("h_Gpt", "; Gpt; Count", 40, 0, 20);
+    histDict["Gpt"] = h_Gpt;
+    h_Gy = new TH1D("h_Gy", "; Gy; Count", 40, -10, 10);
+    histDict["Gy"] = h_Gy;
+    h_GisSignalCalc = new TH1D("h_GisSignalCalc", "; GisSignalCalc; Count", 2, 0, 2);
+    histDict["GisSignalCalc"] = h_GisSignalCalc;
+    h_GisSignalCalcPrompt = new TH1D("h_GisSignalCalcPrompt", "; GisSignalCalcPrompt; Count", 2, 0, 2);
+    histDict["GisSignalCalcPrompt"] = h_GisSignalCalcPrompt;
+    h_GisSignalCalcFeeddown = new TH1D("h_GisSignalCalcFeeddown", "; GisSignalCalcFeeddown; Count", 2, 0, 2);
+    histDict["GisSignalCalcFeeddown"] = h_GisSignalCalcFeeddown;
+  } else {
+    printf("[Error] mode (%s) is not recognized! Exiting ...\n", mode.c_str());
+    exit(0);
+  }
+}
+
+ValidateHist::~ValidateHist() {
+  for (const auto &[key, value] : histDict) {
+    if (value)
+      delete value;
+  }
+
+  output->Close();
+  if (output)
+    delete output;
+}
+
+void ValidateHist::Write() {
+  output->cd();
+
+  for (const auto &[key, value] : histDict) {
+    cout << "Save " << key << endl;
+    value->Write();
+  }
+}
+
+#endif

--- a/MainAnalysis/20241110_SkimValidation/makefile
+++ b/MainAnalysis/20241110_SkimValidation/makefile
@@ -1,0 +1,82 @@
+ROOT=`root-config --cflags --glibs`
+
+MKDIR_OUTPUT=mkdir -p $(PWD)/out
+
+MkdirOutput:
+	$(MKDIR_OUTPUT)
+
+DumpNewSkim: DumpNewSkim.cpp
+	g++ DumpNewSkim.cpp -o DumpNewSkim $(ROOT) \
+		-I$(ProjectBase)/CommonCode/include $(ProjectBase)/CommonCode/library/Messenger.o
+
+DumpOldSkim: DumpOldSkim.cpp
+	g++ DumpOldSkim.cpp -o DumpOldSkim $(ROOT) \
+		-I$(ProjectBase)/CommonCode/include $(ProjectBase)/CommonCode/library/Messenger.o
+
+Validate: Validate.cpp
+	g++ Validate.cpp -o Validate $(ROOT) \
+		-I$(ProjectBase)/CommonCode/include $(ProjectBase)/CommonCode/library/Messenger.o
+
+ValidateData: MkdirOutput DumpNewSkim DumpOldSkim Validate
+	./DumpNewSkim --Input /data/NewSkims23_24/ValidationSamples/20241106_NoEventDrejection/SkimHiForestMiniAOD_UPCPbPb23_HiVertex_279.root \
+				  --Output out/DumpNewSkim --IsData true --SkimDzeroPresenceAbovePTMin 2.0
+
+	./DumpOldSkim --Input /home/data/public/yuchenc/SkimsCheck_20241104/OldSkim/Data/GAP/gmTestFileForNewSkim_20241104_GAP_GapPlusORMinusEMinMinus8p6_Plus9p2_RecoDPtMin2p0.root \
+				  --Output out/DumpOldSkim --IsData true --SkimDzeroPresenceAbovePTMin 2.0
+	
+	./Validate --Input1 out/DumpNewSkim.root --Input2 out/DumpOldSkim.root \
+						 --LegendName1 New --LegendName2 Old \
+						 --PlotName out/ValidateData_New_vs_Old_Skim.pdf
+
+	echo "Diff between old file (<) and new file (>)" > out/DumpSkims.diff
+	echo "Quit 'less out/DumpSkims.diff' by entering 'q'" >> out/DumpSkims.diff
+	diff out/DumpOldSkim.txt out/DumpNewSkim.txt >> out/DumpSkims.diff || echo 'Files differ'
+	less out/DumpSkims.diff
+
+ValidateDataWDsel: MkdirOutput DumpNewSkim DumpOldSkim Validate
+	./DumpNewSkim --Input /data/NewSkims23_24/ValidationSamples/20241106_NoEventDrejection/SkimHiForestMiniAOD_UPCPbPb23_HiVertex_279.root \
+				  --Output out/DumpNewSkim --IsData true --SkimDzeroPresenceAbovePTMin 2.0 --ApplyDSelection true
+
+	./DumpOldSkim --Input /home/data/public/yuchenc/SkimsCheck_20241104/OldSkim/Data/GAP/gmTestFileForNewSkim_20241104_GAP_GapPlusORMinusEMinMinus8p6_Plus9p2_RecoDPtMin2p0.root \
+				  --Output out/DumpOldSkim --IsData true --SkimDzeroPresenceAbovePTMin 2.0 --ApplyDSelection true
+
+	./Validate --Input1 out/DumpNewSkim.root --Input2 out/DumpOldSkim.root \
+						 --LegendName1 New --LegendName2 Old \
+						 --PlotName out/ValidateDataWDSel_New_vs_Old_Skim.pdf
+
+	echo "Diff between old file (<) and new file (>)" > out/DumpSkims.diff
+	echo "Quit 'less out/DumpSkims.diff' by entering 'q'" >> out/DumpSkims.diff
+	diff out/DumpOldSkim.txt out/DumpNewSkim.txt >> out/DumpSkims.diff || echo 'Files differ'
+	less out/DumpSkims.diff
+
+ValidateMC: MkdirOutput DumpNewSkim DumpOldSkim Validate
+	./DumpNewSkim --Input /data/NewSkims23_24/ValidationSamples/20241106_NoEventDrejection/SkimForcedD0Decay100M_BeamA_HiForestMiniAOD_44.root \
+				  --Output out/DumpNewSkim --IsData false --SkimDzeroPresenceAbovePTMin 2.0
+
+	./DumpOldSkim --Input /home/data/public/hannah/mc_productions/OfficialMC_pTHat2/UnmergedForests/ForcedD0Decay100M_BeamA/HiForestMiniAOD_44.root \
+				  --Output out/DumpOldSkim --IsData false --SkimDzeroPresenceAbovePTMin 2.0
+
+	./Validate --Input1 out/DumpNewSkim.root --Input2 out/DumpOldSkim.root \
+						 --LegendName1 New --LegendName2 Old \
+						 --PlotName out/ValidateMC_New_vs_Old_Skim.pdf
+
+	echo "Diff between old file (<) and new file (>)" > out/DumpSkims.diff
+	echo "Quit 'less out/DumpSkims.diff' by entering 'q'" >> out/DumpSkims.diff
+	diff out/DumpOldSkim.txt out/DumpNewSkim.txt >> out/DumpSkims.diff || echo 'Files differ'
+	less out/DumpSkims.diff
+
+ValidateMCWDsel: MkdirOutput DumpNewSkim DumpOldSkim Validate
+	./DumpNewSkim --Input /data/NewSkims23_24/ValidationSamples/20241106_NoEventDrejection/SkimForcedD0Decay100M_BeamA_HiForestMiniAOD_44.root \
+				  --Output out/DumpNewSkim --IsData false --SkimDzeroPresenceAbovePTMin 2.0 --ApplyDSelection true
+
+	./DumpOldSkim --Input /home/data/public/hannah/mc_productions/OfficialMC_pTHat2/UnmergedForests/ForcedD0Decay100M_BeamA/HiForestMiniAOD_44.root \
+				  --Output out/DumpOldSkim --IsData false --SkimDzeroPresenceAbovePTMin 2.0 --ApplyDSelection true
+
+	./Validate --Input1 out/DumpNewSkim.root --Input2 out/DumpOldSkim.root \
+						 --LegendName1 New --LegendName2 Old \
+						 --PlotName out/ValidateMCWDSel_New_vs_Old_Skim.pdf
+
+	echo "Diff between old file (<) and new file (>)" > out/DumpSkims.diff
+	echo "Quit 'less out/DumpSkims.diff' by entering 'q'" >> out/DumpSkims.diff
+	diff out/DumpOldSkim.txt out/DumpNewSkim.txt >> out/DumpSkims.diff || echo 'Files differ'
+	less out/DumpSkims.diff


### PR DESCRIPTION
### Skim Format Validation
- Usage:
	```bash
	# validate the old and new skims (data) with event selections
	make ValidateData
	# validate the old and new skims (data) with event selections + D selections
	make ValidateDataWDsel
	# validate the old and new skims (MC) with event selections
	make ValidateMC
	# validate the old and new skims (MC) with event selections + D selections
	make ValidateMCWDsel
	```
	- Note that the above makefile rule will create an out/DumpSkim.diff file and display the content with `less out/DumpSkim.diff`.
	If the file is empty that means things are aligned btw the two skims, and one can quit 'less out/DumpSkims.diff' by entering 'q'.

- Macro:
	- `DumpNewSkim.cpp`, `DumpOldSkim.cpp`: print and store histograms for comparison

	- `Validate.cpp`: comparison btw two dump output root files

- `ValidateHist.h`:
	Defining histograms for validation
