### PR TITLE
First version of skimming with Condor

### DIFF
--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/CopyToT2.sh
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/CopyToT2.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Remove existing files on T2
+xrdfs root://xrootd5.cmsaf.mit.edu/ ls -R /store/user/$USER/MITHIGAnalysis2024/ >> temp_xrd_delete.txt
+while read -r LINE; do
+  if [[ "$LINE" =~ \.*$ ]]; then
+    xrdfs root://xrootd5.cmsaf.mit.edu/ rm $LINE
+  fi
+done < temp_xrd_delete.txt
+rm temp_xrd_delete.txt
+xrdfs root://xrootd5.cmsaf.mit.edu/ rmdir /store/user/$USER/MITHIGAnalysis2024/
+
+# Copy over current state of Condor dir
+CONDOR_SKIM_DIR=CondorForestReducer_DzeroUPC
+xrdfs root://xrootd5.cmsaf.mit.edu/ mkdir -p /store/user/$USER/MITHIGAnalysis2024/SampleGeneration/$CONDOR_SKIM_DIR
+xrdcp -r -f ../../CommonCode root://xrootd5.cmsaf.mit.edu//store/user/$USER/MITHIGAnalysis2024/
+xrdcp -f ../../SetupAnalysis.sh root://xrootd5.cmsaf.mit.edu//store/user/$USER/MITHIGAnalysis2024/
+xrdcp -r -f include root://xrootd5.cmsaf.mit.edu//store/user/$USER/MITHIGAnalysis2024/SampleGeneration/$CONDOR_SKIM_DIR/
+xrdcp -f ReduceForest.cpp root://xrootd5.cmsaf.mit.edu//store/user/$USER/MITHIGAnalysis2024/SampleGeneration/$CONDOR_SKIM_DIR/
+xrdcp -f makefile root://xrootd5.cmsaf.mit.edu//store/user/$USER/MITHIGAnalysis2024/SampleGeneration/$CONDOR_SKIM_DIR/
+#xrdcp -f RunSkimCondor.sh root://xrootd5.cmsaf.mit.edu//store/user/$USER/MITHIGAnalysis2024/SampleGeneration/$CONDOR_SKIM_DIR/
+#xrdcp -f MakeSkimFileList.sh root://xrootd5.cmsaf.mit.edu//store/user/$USER/MITHIGAnalysis2024/SampleGeneration/$CONDOR_SKIM_DIR/
+#xrdcp -f MakeSkimCondor.sh root://xrootd5.cmsaf.mit.edu//store/user/$USER/MITHIGAnalysis2024/SampleGeneration/$CONDOR_SKIM_DIR/

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/MakeSkimCondor.sh
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/MakeSkimCondor.sh
@@ -121,7 +121,19 @@ xrdfs $XROOTD_SERVER rm $T2_OUTPUT
 sleep 1
 xrdcp -f \$MERGED_ROOT $XROOTD_SERVER/$T2_OUTPUT
 wait
-xrdfs $XROOTD_SERVER ls -l $T2_OUTPUT
+
+# Check if copying over worked. If not, then try again
+T2SIZE=$(xrdfs $XROOTD_SERVER ls -l $T2_OUTPUT | awk '{print $4}')
+wait
+LOCALSIZE=$(ls -l \$MERGED_ROOT | awk '{print $5}')
+if ! (( \$T2SIZE - \$LOCALSIZE )); then
+  xrdcp -f \$MERGED_ROOT $XROOTD_SERVER/$T2_OUTPUT
+  wait
+  sleep 300
+fi
+
+T2FILE=$("
+LOCALFILE=
 
 echo ">>> Done!"
 

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/MakeSkimCondor.sh
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/MakeSkimCondor.sh
@@ -23,8 +23,8 @@ cat > $SCRIPT <<EOF1
 
 CLUSTER=\$1
 PROC=\$2
-ROOT_LIST="rootList_\${CLUSTER}-\${PROC}.txt"
-MERGED_ROOT="merged_\${CLUSTER}-\${PROC}.root"
+ROOT_LIST="rootList_\${CLUSTER}_\${PROC}.txt"
+MERGED_ROOT="merged_\${CLUSTER}_\${PROC}.root"
 
 echo ""
 echo ">>> Host info"
@@ -48,10 +48,12 @@ cmsenv
 git cms-merge-topic CmsHI:forest_CMSSW_14_1_X
 wait
 cd ../../
+which root
+which hadd
 
 echo ""
 echo ">>> Setting up directory"
-xrdcp -r root://xrootd5.cmsaf.mit.edu//store/user/jdlang/MITHIGAnalysis2024 .
+xrdcp -r -f  root://xrootd.cmsaf.mit.edu//store/user/jdlang/MITHIGAnalysis2024 .
 wait
 ls -l
 cd MITHIGAnalysis2024/SampleGeneration/CondorForestReducer_DzeroUPC/
@@ -64,6 +66,7 @@ echo ""
 echo ">>> Compiling skimmer"
 make
 wait
+sleep 1
 if ! [ -f "Execute" ]; then
   echo "ERROR: Unable to compile executable!"
   exit 2
@@ -77,7 +80,7 @@ while read -r ROOT_T2; do
   ROOT_IN="\${ROOT_T2##*/}"
 #  ROOT_OUT="temp_skim_\${CLUSTER}\${PROC}_\${COUNTER}.root"
   ROOT_OUT="tempskim_\${CLUSTER}\${PROC}_\${ROOT_IN}"
-  xrdcp \$ROOT_T2 .
+  xrdcp -f \$ROOT_T2 .
   wait
   if ! [ -f "\$ROOT_IN" ]; then
     echo "--- ERROR! Missing root file: \$ROOT_IN"

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/MakeSkimCondor.sh
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/MakeSkimCondor.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+
+BASENAME=$1
+JOBLIST=$2
+CONFIGDIR=$3
+XROOTD_SERVER=$4
+T2_OUTPUT=$5
+
+SCRIPT="${CONFIGDIR}/${BASENAME}_script.sh"
+CONFIG="${CONFIGDIR}/${BASENAME}_config.condor"
+
+JOBLIST_NAME="${JOBLIST##*/}"
+PROXYFILE=$HOME/$(ls $HOME -lt | grep $USER | grep -m 1 x509 | awk '{print $NF}')
+PROXYFILE_NAME="${PROXYFILE##*/}"
+
+
+
+# MAKE CONDOR SCRIPT ==========================================================
+rm $SCRIPT
+sleep 0.5
+cat > $SCRIPT <<EOF1
+#!/bin/bash
+
+CLUSTER=\$1
+PROC=\$2
+ROOT_LIST="rootList_\${CLUSTER}-\${PROC}.txt"
+MERGED_ROOT="merged_\${CLUSTER}-\${PROC}.root"
+
+echo ""
+echo ">>> Host info"
+hostname
+uname -a
+
+echo ""
+echo ">>> VOMS info"
+unset  X509_USER_KEY
+export X509_USER_KEY=$PROXYFILE_NAME
+voms-proxy-info
+
+echo ""
+echo ">>> Setting up CMSSW_14_1_4_patch5"
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+wait
+cmsrel CMSSW_14_1_4_patch5
+wait
+cd CMSSW_14_1_4_patch5/src/
+cmsenv
+git cms-merge-topic CmsHI:forest_CMSSW_14_1_X
+wait
+cd ../../
+
+echo ""
+echo ">>> Setting up directory"
+xrdcp -r root://xrootd5.cmsaf.mit.edu//store/user/jdlang/MITHIGAnalysis2024 .
+wait
+ls -l
+cd MITHIGAnalysis2024/SampleGeneration/CondorForestReducer_DzeroUPC/
+export ProjectBase=../../
+export PATH=$ProjectBase/CommonCode/binary/:$PATH
+mv ../../../$JOBLIST_NAME .
+ls -l
+
+echo ""
+echo ">>> Compiling skimmer"
+make
+wait
+if ! [ -f "Execute" ]; then
+  echo "ERROR: Unable to compile executable!"
+  exit 2
+fi
+
+echo ""
+echo ">>> Running skimmer"
+COUNTER=0
+HADD_LIST="${BASENAME}_haddlist.txt"
+while read -r ROOT_T2; do
+  ROOT_IN="\${ROOT_T2##*/}"
+#  ROOT_OUT="temp_skim_\${CLUSTER}\${PROC}_\${COUNTER}.root"
+  ROOT_OUT="tempskim_\${CLUSTER}\${PROC}_\${ROOT_IN}"
+  xrdcp \$ROOT_T2 .
+  wait
+  if ! [ -f "\$ROOT_IN" ]; then
+    echo "--- ERROR! Missing root file: \$ROOT_IN"
+    continue
+  fi
+  echo "--- Processing input \${COUNTER}: \$ROOT_IN"
+  ./Execute --Input \$ROOT_IN \\
+    --Output \$ROOT_OUT \\
+    --Year 2024 \\
+    --IsData true \\
+    --ZDCTree zdcanalyzer/zdcrechit \\
+    --ApplyTriggerRejection false \\
+    --ApplyEventRejection true \\
+    --ApplyZDCGapRejection true \\
+    --ApplyDRejection true \\
+    --ZDCMinus1nThreshold 900 \\
+    --ZDCPlus1nThreshold 900 \\
+    --PFTree particleFlowAnalyser/pftree
+  wait
+  
+  echo \$ROOT_OUT >> \$HADD_LIST
+  COUNTER=\$((COUNTER + 1))
+  rm \$ROOT_IN
+  wait
+done < $JOBLIST_NAME
+
+echo ""
+echo ">>> Completed \$COUNTER jobs!"
+ls -lh
+
+echo ""
+echo ">>> Merging root files"
+hadd -ff \$MERGED_ROOT @\$HADD_LIST
+
+echo ""
+echo ">>> Transferring merged root file to T2"
+xrdfs $XROOTD_SERVER rm $T2_OUTPUT
+sleep 1
+xrdcp -f \$MERGED_ROOT $XROOTD_SERVER/$T2_OUTPUT
+wait
+xrdfs $XROOTD_SERVER ls -l $T2_OUTPUT
+
+echo ">>> Done!"
+
+EOF1
+# -----------------------------------------------------------------------------
+echo "Made script: $SCRIPT"
+
+
+
+# MAKE CONDOR CONFIG ==========================================================
+rm $CONFIG
+sleep 0.5
+cat > $CONFIG <<EOF2
+### Job settings
+Universe                = vanilla
+request_disk            = 10GB
+request_memory          = 5GB
+initialdir              = $PWD/
+executable              = $PWD/$SCRIPT
+arguments               = \$(ClusterId) \$(ProcId)
+use_x509userproxy       = True
+x509userproxy           = $PROXYFILE
++AccountingGroup        = "analysis.$USER"
+max_retries             = 1
+
+### File transfer
+should_transfer_files   = YES
+transfer_input_files    = $JOBLIST
+#when_to_transfer_output = ON_EXIT_OR_EVICT
+MAX_TRANSFER_INPUT_MB   = 400
+#on_exit_remove          = (ExitBySignal == False) && (ExitCode == 0)
+
+### Logging
+notification            = Error
+#output                  = ${CONFIGDIR}/${BASENAME}.out
+#error                   = ${CONFIGDIR}/${BASENAME}.err
+#log                     = ${CONFIGDIR}/${BASENAME}.log
+output                  = ${CONFIGDIR}/${BASENAME}_out_\$(ClusterId)_\$(ProcId).txt
+error                   = ${CONFIGDIR}/${BASENAME}_err_\$(ClusterId)_\$(ProcId).txt
+log                     = ${CONFIGDIR}/${BASENAME}_log_\$(ClusterId)_\$(ProcId).txt
+
+### Server settings
+MY.WantOS               = "el9"
+Requirements            = ( (OpSysAndVer =?= "AlmaLinux9" || OpSysAndVer =?= "CentOS9") && (Arch =?= "X86_64") && (BOSCOCluster =!= "t3serv008.mit.edu") && (BOSCOCluster =!= "ce03.cmsaf.mit.edu") && (BOSCOCluster =!= "eofe8.mit.edu") )
++SingularityImage       = "/cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/el9:x86_64-d20241130"
++DESIRED_Sites          = "mit_tier2,mit_tier3,T2_AT_Vienna,T2_BE_IIHE,T2_BE_UCL,T2_BR_SPRACE,T2_BR_UERJ,T2_CH_CERN,T2_CH_CERN_AI,T2_CH_CERN_HLT,T2_CH_CERN_Wigner,T2_CH_CSCS,T2_CH_CSCS_HPC,T2_CN_Beijing,T2_DE_DESY,T2_DE_RWTH,T2_EE_Estonia,T2_ES_CIEMAT,T2_ES_IFCA,T2_FI_HIP,T2_FR_CCIN2P3,T2_FR_GRIF_IRFU,T2_FR_GRIF_LLR,T2_FR_IPHC,T2_GR_Ioannina,T2_HU_Budapest,T2_IN_TIFR,T2_IT_Bari,T2_IT_Legnaro,T2_IT_Pisa,T2_IT_Rome,T2_KR_KISTI,T2_MY_SIFIR,T2_MY_UPM_BIRUNI,T2_PK_NCP,T2_PL_Swierk,T2_PL_Warsaw,T2_PT_NCG_Lisbon,T2_RU_IHEP,T2_RU_INR,T2_RU_ITEP,T2_RU_JINR,T2_RU_PNPI,T2_RU_SINP,T2_TH_CUNSTDA,T2_TR_METU,T2_TW_NCHC,T2_UA_KIPT,T2_UK_London_IC,T2_UK_SGrid_Bristol,T2_UK_SGrid_RALPP,T2_US_Caltech,T2_US_Florida,T2_US_Nebraska,T2_US_Purdue,T2_US_UCSD,T2_US_Vanderbilt,T2_US_Wisconsin,T3_CH_CERN_CAF,T3_CH_CERN_DOMA,T3_CH_CERN_HelixNebula,T3_CH_CERN_HelixNebula_REHA,T3_CH_CMSAtHome,T3_CH_Volunteer,T3_US_HEPCloud,T3_US_NERSC,T3_US_OSG,T3_US_PSC,T3_US_SDSC,T3_US_MIT"
+
+queue 1
+
+EOF2
+# -----------------------------------------------------------------------------
+echo "Made config: $CONFIG"
+
+sleep 0.5
+condor_submit $CONFIG
+wait

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/MakeSkimFileList.sh
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/MakeSkimFileList.sh
@@ -4,9 +4,21 @@ XROOTD_SERVER=$1
 T2_INPUT_DIR=$2
 FILELIST=$3
 
+# WARNING! ONLY USE THIS FOR xrdfs FUNCTIONS, NEVER FOR TRANSFERS!!!
+XROOTD_FS=(
+  "root://xrootd3.cmsaf.mit.edu/"
+  "root://xrootd4.cmsaf.mit.edu/"
+  "root://xrootd5.cmsaf.mit.edu/"
+  "root://xrootd6.cmsaf.mit.edu/"
+  "root://xrootd7.cmsaf.mit.edu/"
+  "root://xrootd8.cmsaf.mit.edu/"
+  "root://xrootd9.cmsaf.mit.edu/"
+)
+RND=$((RANDOM % 7))
+
 # Make list of all files in parent dir
 rm $FILELIST
-xrdfs $XROOTD_SERVER ls -R $T2_INPUT_DIR >> $FILELIST
+xrdfs ${XROOTD_FS[$RND]} ls -R $T2_INPUT_DIR >> $FILELIST
 wait
 if [ -z "$FILELIST" ]; then
   echo "No files found in remote directory: $T2_INPUT_DIR"

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/MakeSkimFileList.sh
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/MakeSkimFileList.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+XROOTD_SERVER=$1
+T2_INPUT_DIR=$2
+FILELIST=$3
+
+# Make list of all files in parent dir
+rm $FILELIST
+xrdfs $XROOTD_SERVER ls -R $T2_INPUT_DIR >> $FILELIST
+wait
+if [ -z "$FILELIST" ]; then
+  echo "No files found in remote directory: $T2_INPUT_DIR"
+  exit 1
+else
+  echo "Building file list for remote directory: $T2_INPUT_DIR"
+fi
+# Temp file for valid paths
+TEMPLIST=$(mktemp)
+FILE_COUNTER=0
+# Keep only paths ending with '.root'
+while read -r LINE; do
+  if [[ "$LINE" =~ \.root$ ]]; then
+    echo "$XROOTD_SERVER/$LINE" >> "$TEMPLIST"
+    wait
+    FILE_COUNTER=$((FILE_COUNTER + 1))
+    if ! (( $FILE_COUNTER % 100 )); then
+      echo "Found $FILE_COUNTER files..."
+    fi
+  else
+    continue
+  fi
+done < $FILELIST
+# Replace the original file with the temp file
+mv "$TEMPLIST" "$FILELIST"
+wait
+
+echo "Found $FILE_COUNTER root files in $T2_INPUT_DIR"

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/README.md
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/README.md
@@ -1,4 +1,18 @@
 # Setup
+
+You will need an account for 
+[MIT SubMIT](https://submit.mit.edu/submit-users-guide/index.html) and a 
+[CERN/CMS certificate](https://uscms.org/uscms_at_work/computing/getstarted/get_grid_cert.shtml). 
+If you need a SubMIT account you can [request one here](https://submit.mit.edu) 
+through the SubMIT Portal. You can only use an ssh key to autheticate!
+Passwords do not work.
+
+Connect to Submit:
+```bash
+ssh <user>@submit.mit.edu
+```
+
+Navigate to your working directory and install CMSSW:
 ```bash
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 cmsrel CMSSW_14_1_4_patch5
@@ -8,3 +22,151 @@ git cms-merge-topic CmsHI:forest_CMSSW_14_1_X
 cd -
 ```
 
+Clone the MITHIGAnalysis2024 repository:
+```bash
+git clone --recursive git@github.com:ginnocen/MITHIGAnalysis2024.git
+cd MITHIGAnalysis2024/
+source SetupAnalysis.sh
+cd SampleGeneration/20241204_CondorForestReducer_DzeroUPC/
+source clean.sh
+```
+
+You should be ready. If you make changes to `ReduceForest.cpp`, `makefile`, or 
+change anything under the `include/` folder or `MITHIGAnalysis2024/CommonCode/`,
+then you will need to update the slimmed repo files on `T2_US_MIT`. Edit the 
+paths in `CopyToT2.sh` and run with:
+```bash
+bash CopyToT2.sh
+```
+
+# Skimming with Condor
+
+## Running
+
+Refresh your VOMS proxy and run `RunSkimCondor.sh`:
+```bash
+voms-proxy-init -rfc -voms cms -valid 72:00
+cp /tmp/x509up_u'$(id -u)' ~/
+
+bash RunSkimCondor.sh
+```
+
+Check the status of condor jobs with:
+```bash
+condor_q
+```
+
+Kill or remove bad jobs with:
+```bash
+condor_rm <job_id>
+```
+
+Once jobs are complete (whether successful or failed), they will no longer
+appear on the `condor_q` list.
+
+Log files are saved to `condorConfigs/<YYYYMMDD>_<RUN>_<PD>/`:
+```bash
+# log of job and server status
+<RUN>_HIForward<PD>_log_<job_id>_0.txt
+# log of errors printed by the job scripts (some outputs will print here too)
+<RUN>_HIForward<PD>_err_<job_id>_0.txt
+# log of print statements from job scripts
+<RUN>_HIForward<PD>_out_<job_id>_0.txt
+```
+
+
+## Making Changes
+
+Edit `RunSkimCondor.sh` to select the runs and PD range to skim over. You can 
+also edit `MakeSkimFileList.sh` and `MakeSkimCondor.sh` to change the Condor 
+configuration and job script template without having to copy changed files 
+over to T2.
+
+> [!WARNING]
+> _Only_ use non-numbered xrootd servers to transfer files, such as
+> `root://xrootd.cmsaf.mit.edu/`! Specifying servers with numbers (e.g. 
+> `xrootd10`) will not speed up transfers, and may damage the servers if used 
+> for file transfers!
+
+
+## Important Files
+
+**RunSkimCondor.sh**
+
+Loops over the configured list of runs and PDs and submits one job for each
+run + PD combination. You can also edit this to change the source and output 
+locations on `T2_US_MIT`.
+
+**MakeSkimFileList.sh**
+
+Makes a master list of file paths on `T2_US_MIT` that will be filtered and 
+processed in jobs.
+
+**MakeSkimCondor.sh**
+
+Creates the Condor submission file and the bash script that is executed on
+the Condor servers. The job script starts after `cat > $SCRIPT <<EOF1` and ends
+at the line `EOF1`. The Condor config starts after `cat > $CONFIG <<EOF2` and
+ends at `EOF2`.
+
+**CopyToT2.sh**
+
+Copies essential files from the local `MITHIGAnalysis2024` repo to `T2_US_MIT`,
+where they are copied to every server at the start of a new job. This should
+only be needed if `ReduceForest.cpp`, `makefile`, `include/` or 
+`MITHIGAnalysis2024/CommonCode/` are changed.
+
+# Useful Commands
+
+## Condor
+
+```bash
+condor_submit <condor_config_file>
+condor_q
+condor_rm <job_id>
+```
+
+
+## xrootd
+
+**CERN eos:** `root://eoscms.cern.ch/` `/store/group/phys_heavyions/<user>/`
+**MIT T2:** `root://xrootd.cmsaf.mit.edu/` `/store/user/<user>/`
+
+```bash
+# Recursive list
+xrdfs <server> ls -R -l <path>
+# Make directory
+xrdfs <server> mkdir -p <path/new_dir>
+
+# Copy
+xrdcp <server//path/new_dir> <local/path>
+# Recursive copy for directory
+xrdcp -r <server//path/dir> <local/path>
+# Forced copy (overwrite)
+xrdcp -f <server//path/file> <local/path>
+
+# Delete file
+xrdfs <server> rm <path/file.ext>
+# Delete directory
+xrdfs <server> rmdir <path/dir>
+```
+
+
+## VOMS
+
+```bash
+voms-proxy-init --rfc --voms cms -valid 72:00
+voms-proxy-info
+```
+
+To make it easier to initiate proxies, add this to `~/.bashrc`:
+```bash
+alias proxy='voms-proxy-init -rfc -voms cms -valid 72:00 ; cp /tmp/x509up_u'$(id -u)' ~/ ;'
+export PROXYFILE=~/x509up_u$(id -u)
+```
+Reset your terminal:
+```bash
+hash -r
+source ~/.bashrc
+```
+From now on, you can initiate a new proxy with the command `proxy`!

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/README.md
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/README.md
@@ -1,0 +1,10 @@
+# Setup
+```bash
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+cmsrel CMSSW_14_1_4_patch5
+cd CMSSW_14_1_4_patch5/src/
+cmsenv
+git cms-merge-topic CmsHI:forest_CMSSW_14_1_X
+cd -
+```
+

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/ReduceForest.cpp
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/ReduceForest.cpp
@@ -1,0 +1,298 @@
+// ===================================================
+// Script Based on Yi Chen Reducer script
+// Yi Chen (Vanderbilt) Yi.Chen@cern.ch
+// https://github.com/FHead/PhysicsZHadronEEC
+// ===================================================
+
+#include <iostream>
+#include <memory>
+using namespace std;
+
+#include "TFile.h"
+#include "TLorentzVector.h"
+#include "TTree.h"
+
+#include "CommandLine.h"
+#include "CommonFunctions.h"
+#include "Messenger.h"
+#include "ProgressBar.h"
+
+#include "TrackResidualCorrector.h"
+#include "tnp_weight.h"
+#include "trackingEfficiency2017pp.h"
+#include "trackingEfficiency2018PbPb.h"
+#include "trackingEfficiency2023PbPb.h"
+
+#include "include/DmesonSelection.h"
+
+bool logical_or_vectBool(std::vector<bool>* vec) {
+    return std::any_of(vec->begin(), vec->end(), [](bool b) { return b; });
+}
+
+int main(int argc, char *argv[]);
+double GetMaxEnergyHF(PFTreeMessenger *M, double etaMin, double etaMax);
+
+int main(int argc, char *argv[]) {
+  string VersionString = "V8";
+
+  CommandLine CL(argc, argv);
+
+  vector<string> InputFileNames = CL.GetStringVector("Input");
+  string OutputFileName = CL.Get("Output");
+
+  // bool DoGenLevel                    = CL.GetBool("DoGenLevel", true);
+  bool IsData = CL.GetBool("IsData", false);
+  int Year = CL.GetInt("Year", 2023);
+  double Fraction = CL.GetDouble("Fraction", 1.00);
+  float ZDCMinus1nThreshold = CL.GetDouble("ZDCMinus1nThreshold", 1000.);
+  float ZDCPlus1nThreshold = CL.GetDouble("ZDCPlus1nThreshold", 1100.);
+  bool ApplyTriggerRejection = CL.GetBool("ApplyTriggerRejection", false);
+  bool ApplyEventRejection = CL.GetBool("ApplyEventRejection", false);
+  bool ApplyZDCGapRejection = CL.GetBool("ApplyZDCGapRejection", false);
+  bool ApplyDRejection = CL.GetBool("ApplyDRejection", false);
+  string PFTreeName = CL.Get("PFTree", "particleFlowAnalyser/pftree");
+  string DGenTreeName = CL.Get("DGenTree", "Dfinder/ntGen");
+  string ZDCTreeName = CL.Get("ZDCTree", "zdcanalyzer/zdcrechit");
+  TFile OutputFile(OutputFileName.c_str(), "RECREATE");
+  TTree Tree("Tree", Form("Tree for UPC Dzero analysis (%s)", VersionString.c_str()));
+  TTree InfoTree("InfoTree", "Information");
+
+  DzeroUPCTreeMessenger MDzeroUPC;
+  MDzeroUPC.SetBranch(&Tree);
+
+  for (string InputFileName : InputFileNames) {
+    TFile* InputFile = TFile::Open(InputFileName.c_str());
+    //std::unique_ptr<TFile> InputFile = TFile::Open(InputFileName.c_str());
+
+    HiEventTreeMessenger MEvent(InputFile);
+    PbPbUPCTrackTreeMessenger MTrackPbPbUPC(InputFile);
+    GenParticleTreeMessenger MGen(InputFile);
+    PFTreeMessenger MPF(InputFile, PFTreeName);
+    SkimTreeMessenger MSkim(InputFile);
+    TriggerTreeMessenger MTrigger(InputFile);
+    DzeroTreeMessenger MDzero(InputFile);
+    DzeroGenTreeMessenger MDzeroGen(InputFile, DGenTreeName);
+    ZDCTreeMessenger MZDC(InputFile, ZDCTreeName);
+    METFilterTreeMessenger MMETFilter(InputFile);
+
+    int EntryCount = MEvent.GetEntries() * Fraction;
+    ProgressBar Bar(cout, EntryCount);
+    Bar.SetStyle(-1);
+
+    /////////////////////////////////
+    //////// Main Event Loop ////////
+    /////////////////////////////////
+
+    for (int iE = 0; iE < EntryCount; iE++) {
+      if (EntryCount < 300 || (iE % (EntryCount / 250)) == 0) {
+        Bar.Update(iE);
+        Bar.Print();
+      }
+
+      MEvent.GetEntry(iE);
+      MGen.GetEntry(iE);
+      MTrackPbPbUPC.GetEntry(iE);
+      MPF.GetEntry(iE);
+      MSkim.GetEntry(iE);
+      MTrigger.GetEntry(iE);
+      MDzero.GetEntry(iE);
+      if (IsData == false)
+        MDzeroGen.GetEntry(iE);
+      MZDC.GetEntry(iE);
+      MDzeroUPC.Clear();
+      MMETFilter.GetEntry(iE);
+
+      ////////////////////////////////////////
+      ////////// Global event stuff //////////
+      ////////////////////////////////////////
+
+      MDzeroUPC.Run = MEvent.Run;
+      MDzeroUPC.Lumi = MEvent.Lumi;
+      MDzeroUPC.Event = MEvent.Event;
+
+      ////////////////////////////
+      ////////// Vertex //////////
+      ////////////////////////////
+
+      int BestVertex = -1;
+
+      for (int i = 0; i < MTrackPbPbUPC.nVtx; i++) {
+        if (BestVertex < 0 || MTrackPbPbUPC.ptSumVtx->at(i) > MTrackPbPbUPC.ptSumVtx->at(BestVertex))
+          BestVertex = i;
+      }
+      if (BestVertex >= 0) {
+        MDzeroUPC.VX = MTrackPbPbUPC.xVtx->at(BestVertex);
+        MDzeroUPC.VY = MTrackPbPbUPC.yVtx->at(BestVertex);
+        MDzeroUPC.VZ = MTrackPbPbUPC.zVtx->at(BestVertex);
+        MDzeroUPC.VXError = MTrackPbPbUPC.xErrVtx->at(BestVertex);
+        MDzeroUPC.VYError = MTrackPbPbUPC.yErrVtx->at(BestVertex);
+        MDzeroUPC.VZError = MTrackPbPbUPC.zErrVtx->at(BestVertex);
+      }
+      MDzeroUPC.nVtx = MTrackPbPbUPC.nVtx;
+
+      /////////////////////////////////////
+      ////////// Event selection //////////
+      /////////////////////////////////////
+      if (IsData == false) {
+        MDzeroUPC.Gsize = MDzeroGen.Gsize;
+        for (int iDGen = 0; iDGen < MDzeroGen.Gsize; iDGen++) {
+          MDzeroUPC.Gpt->push_back(MDzeroGen.Gpt[iDGen]);
+          MDzeroUPC.Gy->push_back(MDzeroGen.Gy[iDGen]);
+          bool isSignalGen =
+              (MDzeroGen.GisSignal[iDGen] == 1 || MDzeroGen.GisSignal[iDGen] == 2) && MDzeroGen.Gpt[iDGen] > 0.;
+          bool isPromptGen = MDzeroGen.GBAncestorpdgId[iDGen] == 0;
+          bool isFeeddownGen = (MDzeroGen.GBAncestorpdgId[iDGen] >= 500 && MDzeroGen.GBAncestorpdgId[iDGen] < 600) ||
+                               (MDzeroGen.GBAncestorpdgId[iDGen] > -600 && MDzeroGen.GBAncestorpdgId[iDGen] <= -500);
+          MDzeroUPC.GisSignalCalc->push_back(isSignalGen);
+          MDzeroUPC.GisSignalCalcPrompt->push_back(isSignalGen && isPromptGen);
+          MDzeroUPC.GisSignalCalcFeeddown->push_back(isSignalGen && isFeeddownGen);
+        }
+      }
+      if (IsData == true) {
+        if (Year == 2023) {
+          int HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000_2023 =
+              MTrigger.CheckTriggerStartWith("HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000");
+          int HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000_2023 =
+              MTrigger.CheckTriggerStartWith("HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000");
+          int HLT_HIUPC_ZDC1nOR_SinglePixelTrackLowPt_MaxPixelCluster400_2023 =
+              MTrigger.CheckTriggerStartWith("HLT_HIUPC_ZDC1nOR_SinglePixelTrackLowPt_MaxPixelCluster400");
+          int HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000_2023 =
+              MTrigger.CheckTriggerStartWith("HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000");
+          bool isL1ZDCOr = HLT_HIUPC_ZDC1nOR_SinglePixelTrackLowPt_MaxPixelCluster400_2023 == 1 ||
+                           HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000_2023 == 1;
+          bool isL1ZDCXORJet8 = HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster50000_2023 == 1 ||
+                                HLT_HIUPC_SingleJet8_ZDC1nAsymXOR_MaxPixelCluster50000_2023 == 1;
+          MDzeroUPC.isL1ZDCOr = isL1ZDCOr;
+          MDzeroUPC.isL1ZDCXORJet8 = isL1ZDCXORJet8;
+          MDzeroUPC.isL1ZDCXORJet12 = false;
+          MDzeroUPC.isL1ZDCXORJet16 = false;
+          if (ApplyTriggerRejection && IsData && (isL1ZDCOr == false && isL1ZDCXORJet8 == false))
+             continue;
+        }
+        else if (Year == 2024){
+          int HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000 = MTrigger.CheckTriggerStartWith("HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000_v13");
+          int HLT_HIUPC_ZDC1nOR_MaxPixelCluster10000 = MTrigger.CheckTriggerStartWith("HLT_HIUPC_ZDC1nOR_MaxPixelCluster10000_v2");
+          int HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster10000 = MTrigger.CheckTriggerStartWith("HLT_HIUPC_SingleJet8_ZDC1nXOR_MaxPixelCluster10000");
+          bool isL1ZDCOr = HLT_HIUPC_ZDC1nOR_MinPixelCluster400_MaxPixelCluster10000 == 1 || HLT_HIUPC_ZDC1nOR_MaxPixelCluster10000 == 1;
+          MDzeroUPC.isL1ZDCOr = isL1ZDCOr;
+          MDzeroUPC.isL1ZDCXORJet8 = false;
+          MDzeroUPC.isL1ZDCXORJet12 = false;
+          MDzeroUPC.isL1ZDCXORJet16 = false;
+          if (ApplyTriggerRejection && IsData && isL1ZDCOr == false) continue;
+        }
+     }
+     if (IsData == true) {
+        MDzeroUPC.ZDCsumPlus = MZDC.sumPlus;
+        MDzeroUPC.ZDCsumMinus = MZDC.sumMinus;
+        bool selectedBkgFilter = MSkim.ClusterCompatibilityFilter == 1 && MMETFilter.cscTightHalo2015Filter;
+        bool selectedVtxFilter = MSkim.PVFilter == 1 && fabs(MTrackPbPbUPC.zVtx->at(0)) < 15.;
+        if (ApplyEventRejection && IsData && (selectedBkgFilter == false || selectedVtxFilter == false)) continue;
+        MDzeroUPC.selectedBkgFilter = selectedBkgFilter;
+        MDzeroUPC.selectedVtxFilter = selectedVtxFilter;
+        bool ZDCgammaN = (MZDC.sumMinus > ZDCMinus1nThreshold && MZDC.sumPlus < ZDCPlus1nThreshold);
+        bool ZDCNgamma = (MZDC.sumMinus < ZDCMinus1nThreshold && MZDC.sumPlus > ZDCPlus1nThreshold);
+        MDzeroUPC.ZDCgammaN = ZDCgammaN;
+        MDzeroUPC.ZDCNgamma = ZDCNgamma;
+        // Loop through the specified ranges for gapgammaN and gapNgamma
+        // gammaN[4] and Ngamma[4] are nominal selection criteria
+        float EMaxHFPlus = GetMaxEnergyHF(&MPF, 3., 5.2);
+        float EMaxHFMinus = GetMaxEnergyHF(&MPF, -5.2, -3.);
+        MDzeroUPC.HFEMaxPlus = EMaxHFPlus;
+        MDzeroUPC.HFEMaxMinus = EMaxHFMinus;
+        bool gapgammaN = EMaxHFPlus < 9.2;
+        bool gapNgamma = EMaxHFMinus < 8.6;
+        MDzeroUPC.gapgammaN = gapgammaN;
+        MDzeroUPC.gapNgamma = gapNgamma;
+        bool gammaN_default = ZDCgammaN && gapgammaN;
+        bool Ngamma_default = ZDCNgamma && gapNgamma;
+        if (ApplyZDCGapRejection && IsData && gammaN_default == false && Ngamma_default == false) continue;
+        for (double gapgammaN_threshold = 5.2; gapgammaN_threshold <= 13.2; gapgammaN_threshold += 1.0) {
+          bool gapgammaN = GetMaxEnergyHF(&MPF, 3.0, 5.2) < gapgammaN_threshold;
+          bool gammaN_ = ZDCgammaN && gapgammaN;
+          MDzeroUPC.gammaN->push_back(gammaN_);
+        }
+        for (double gapNgamma_threshold = 4.6; gapNgamma_threshold <= 12.6; gapNgamma_threshold += 1.0) {
+          bool gapNgamma = GetMaxEnergyHF(&MPF, -5.2, -3.0) < gapNgamma_threshold;
+          bool Ngamma_ = ZDCNgamma && gapNgamma;
+          MDzeroUPC.Ngamma->push_back(Ngamma_);
+        }
+        //bool evtselgammaNNgamma = logical_or_vectBool(MDzeroUPC.gammaN) || logical_or_vectBool(MDzeroUPC.Ngamma);
+        //if (ApplyEventRejection && evtselgammaNNgamma == false) continue;
+      } // end of if (IsData == true)
+      int nTrackInAcceptanceHP = 0;
+      for (int iTrack = 0; iTrack < MTrackPbPbUPC.nTrk; iTrack++) {
+        if (MTrackPbPbUPC.trkPt->at(iTrack) <= 0.5)
+          continue;
+        if (fabs(MTrackPbPbUPC.trkEta->at(iTrack)) >= 2.4)
+          continue;
+        if (MTrackPbPbUPC.highPurity->at(iTrack) == false)
+          continue;
+        nTrackInAcceptanceHP++;
+      }
+      MDzeroUPC.nTrackInAcceptanceHP = nTrackInAcceptanceHP;
+      int countSelDzero = 0;
+      for (int iD = 0; iD < MDzero.Dsize; iD++) {
+        if (ApplyDRejection == true && IsData && DmesonSelectionPrelim23(MDzero, iD) == false) continue;
+        countSelDzero++;
+        MDzeroUPC.Dpt->push_back(MDzero.Dpt[iD]);
+        MDzeroUPC.Dy->push_back(MDzero.Dy[iD]);
+        MDzeroUPC.Dmass->push_back(MDzero.Dmass[iD]);
+        MDzeroUPC.Dtrk1Pt->push_back(MDzero.Dtrk1Pt[iD]);
+        MDzeroUPC.Dtrk2Pt->push_back(MDzero.Dtrk2Pt[iD]);
+        MDzeroUPC.Dchi2cl->push_back(MDzero.Dchi2cl[iD]);
+        MDzeroUPC.DsvpvDistance->push_back(MDzero.DsvpvDistance[iD]);
+        MDzeroUPC.DsvpvDisErr->push_back(MDzero.DsvpvDisErr[iD]);
+        MDzeroUPC.DsvpvDistance_2D->push_back(MDzero.DsvpvDistance_2D[iD]);
+        MDzeroUPC.DsvpvDisErr_2D->push_back(MDzero.DsvpvDisErr_2D[iD]);
+        MDzeroUPC.Dalpha->push_back(MDzero.Dalpha[iD]);
+        MDzeroUPC.Ddtheta->push_back(MDzero.Ddtheta[iD]);
+        MDzeroUPC.DpassCut->push_back(DmesonSelectionPrelim23(MDzero,iD));
+        if (IsData == false) {
+          MDzeroUPC.Dgen->push_back(MDzero.Dgen[iD]);
+          bool isSignalGenMatched = MDzero.Dgen[iD] == 23333 && MDzero.Dgenpt[iD] > 0.;
+          bool isPromptGenMatched = MDzero.DgenBAncestorpdgId[iD] == 0;
+          bool isFeeddownGenMatched = (MDzero.DgenBAncestorpdgId[iD] >= 500 && MDzero.DgenBAncestorpdgId[iD] < 600) ||
+                                      (MDzero.DgenBAncestorpdgId[iD] > -600 && MDzero.DgenBAncestorpdgId[iD] <= -500);
+          MDzeroUPC.DisSignalCalc->push_back(isSignalGenMatched);
+          MDzeroUPC.DisSignalCalcPrompt->push_back(isSignalGenMatched && isPromptGenMatched);
+          MDzeroUPC.DisSignalCalcFeeddown->push_back(isSignalGenMatched && isFeeddownGenMatched);
+        }
+      }
+      MDzeroUPC.Dsize = countSelDzero;
+      MDzeroUPC.FillEntry();
+    }
+
+    Bar.Update(EntryCount);
+    Bar.Print();
+    Bar.PrintLine();
+
+    InputFile->Close();
+  }
+
+  OutputFile.cd();
+  Tree.Write();
+  InfoTree.Write();
+
+  OutputFile.Close();
+
+  return 0;
+}
+
+// ============================================================================ //
+// Function to Retrieve Maximum Energy in HF Region within Specified Eta Range
+// ============================================================================ //
+double GetMaxEnergyHF(PFTreeMessenger *M, double etaMin = 3., double etaMax = 5.) {
+  if (M == nullptr)
+    return -1;
+  if (M->Tree == nullptr)
+    return -1;
+
+  double EMax = 0;
+  for (int iPF = 0; iPF < M->ID->size(); iPF++) {
+    if ((M->ID->at(iPF) == 6 || M->ID->at(iPF) == 7) && M->Eta->at(iPF) > etaMin && M->Eta->at(iPF) < etaMax) {
+      if (M->E->at(iPF) > EMax)
+        EMax = M->E->at(iPF);
+    }
+  }
+  return EMax;
+}

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/RunExamples.sh
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/RunExamples.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+rm -rf Output/
+mkdir -p Output/
+
+###################
+### Data PbPb 23 ###
+###################
+
+#./Execute --Input /data/NewSkims23_24/20241102_ForestOldReco23sample_Dataexample/HiForestMiniAOD_UPCPbPb23_HiVertex_279.root \
+#   --Output skim_UPCPbPb23_HiVertex_279.root \
+#   --Year 2023 \
+#   --IsData true \
+#   --ApplyTriggerRejection false \
+#   --ApplyEventRejection false \
+#   --ApplyZDCGapRejection false \
+#   --ApplyDRejection false \
+#   --ZDCMinus1nThreshold 1000 \
+#   --ZDCPlus1nThreshold 1100 \
+#   --PFTree particleFlowAnalyser/pftree
+
+#################
+### Data PbPb 24 ###
+#################
+
+#./Execute   --Input root://xrootd.cmsaf.mit.edu//store/user/jdlang/run3_2024PromptReco/Run3UPC2024_PromptReco_388000_HIForward0/HIForward0/crab_Run3UPC2024_PromptReco_388000_HIForward0/241118_225127/0000/HiForestMiniAOD_1.root \
+./Execute --Input HiForestMiniAOD_1.root \
+   --Output skim_run388000_test1.root \
+   --Year 2024 \
+   --IsData true \
+   --ZDCTree zdcanalyzer/zdcrechit \
+   --ApplyTriggerRejection false \
+   --ApplyEventRejection true \
+   --ApplyZDCGapRejection true \
+   --ApplyDRejection true \
+   --ZDCMinus1nThreshold 900 \
+   --ZDCPlus1nThreshold 900 \
+   --PFTree particleFlowAnalyser/pftree \
+
+###################
+### MC Gen PbPb ###
+###################
+
+#./Execute --Input /home/data/public/hannah/mc_productions/OfficialMC_pTHat2/UnmergedForests/ForcedD0Decay100M_BeamA/HiForestMiniAOD_44.root \
+#   --Output Output/output_44.root \
+#   --Year 2023 \
+#   --IsData false \
+#   --ApplyTriggerRejection false \
+#   --ApplyEventRejection false \
+#   --ApplyZDCGapRejection false \
+#   --ApplyDRejection false \
+#   --PFTree particleFlowAnalyser/pftree \
+#   --DGenTree Dfinder/ntGen

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/RunSkimCondor.sh
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/RunSkimCondor.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+XROOTD_SERVER="root://xrootd5.cmsaf.mit.edu/"
+T2_PARENT_DIR="/store/user/jdlang/run3_2024PromptReco"
+T2_OUTPUT_DIR="/store/user/jdlang/run3_2024PromptRecoSkims_HIForward_20241211"
+RUNLIST=(
+  388000
+#  388004 388005 388006 388020
+#  388021 388037 388038 388039 388048
+#  388049 388050 388056 388090 388091
+#  388092 388095 388121 388122 388168
+### Runs below are not processed!
+#  388192 388305 388306 388317 388349
+#  388350 388368 388369 388384 388389 
+#  388390 388401 388402 388418 388419 
+#  388425 388450 388468 388475 388476
+#  388574 388575 388576 388577 388578
+#  388579 388582 388583 388613 388620
+#  388622 388624 388710 388711 388713
+)
+PDMIN=0
+PDMAX=19
+#FILES_PER_JOB=100
+
+DATE=$(date +%Y%m%d)
+
+xrdfs $XROOTD_SERVER mkdir -p $T2_OUTPUT_DIR
+
+submit_condor_jobs() {
+  local BASENAME=$1
+  local JOBLIST=$2
+  local CONFIGDIR=$3
+  T2_OUTPUT="${T2_OUTPUT_DIR}/run${RUN}_HIForward${PD}.root"
+  ./MakeSkimCondor.sh $BASENAME $JOBLIST $CONFIGDIR $XROOTD_SERVER $T2_OUTPUT
+  wait
+  sleep 0.2
+  return 0
+}
+
+for RUN in ${RUNLIST[@]}; do
+  for (( PD=$PDMIN; PD<=PDMAX; PD++ )); do
+    CONFIGDIR="condorConfigs/${DATE}_${RUN}_${PD}"
+    mkdir -p $CONFIGDIR
+    T2_INPUT_DIR="${T2_PARENT_DIR}/Run3UPC2024_PromptReco_${RUN}_HIForward${PD}/"
+    FILELIST="filelist_${RUN}_${PD}.txt"
+    ./MakeSkimFileList.sh $XROOTD_SERVER $T2_INPUT_DIR $FILELIST
+    # Iterate through list to make individual jobs
+#    PART=1
+    BASENAME="${RUN}_HIForward${PD}"
+    JOBLIST="${CONFIGDIR}/${BASENAME}_joblist.txt"
+    rm $JOBLIST
+    FILE_COUNTER=0
+    while IFS= read -r LINE; do
+      echo "$LINE" >> "$JOBLIST"
+      FILE_COUNTER=$((FILE_COUNTER + 1))
+#      if ! (( $FILE_COUNTER % FILES_PER_JOB )); then
+#        submit_condor_jobs $BASENAME $JOBLIST $CONFIGDIR
+#        wait
+#        # Make new job file
+#        PART=$((PART + 1))
+#        BASENAME="${RUN}_HIForward${PD}_${PART}"
+#        JOBLIST="${CONFIGDIR}/${BASENAME}_joblist.txt"
+#        rm $JOBLIST
+#      fi
+    done < $FILELIST
+    # Submit final job file list
+    submit_condor_jobs $BASENAME $JOBLIST $CONFIGDIR
+    sleep 10 # add 10 second pause between PDs to offset streams from T2_MIT
+  done # end PD loop
+  sleep 60 # add 1 minute pause between runs to offset streams from T2_MIT
+done # end RUN loop

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/RunSkimCondor.sh
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/RunSkimCondor.sh
@@ -4,8 +4,8 @@ XROOTD_SERVER="root://xrootd.cmsaf.mit.edu/"
 T2_PARENT_DIR="/store/user/jdlang/run3_2024PromptReco"
 T2_OUTPUT_DIR="/store/user/jdlang/run3_2024PromptRecoSkims_HIForward_20241211"
 RUNLIST=(
-#  388000 388004 388005 388006 388020
-#  388021 388037 388038 388039 388048
+  388000 388004 388005 388006 388020
+  388021 388037 388038 388039 388048
   388049 388050 388056 388090 388091
   388092 388095 388121 388122 388168
 ### Runs below are not processed!
@@ -54,7 +54,6 @@ for RUN in ${RUNLIST[@]}; do
     done < $FILELIST
     # Submit final job file list
     submit_condor_jobs $BASENAME $JOBLIST $CONFIGDIR
-    sleep 3 # add pause between PDs to offset streams from T2_MIT
+    sleep 2 # small pause between PDs to offset streams from T2_MIT
   done # end PD loop
-  sleep 15 # add pause between runs to offset streams from T2_MIT
 done # end RUN loop

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/clean.sh
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/clean.sh
@@ -1,0 +1,36 @@
+CMSFOLDER=$HOME/CMSSW_14_1_4_patch5/src
+WORKFOLDER=$PWD
+
+if [ ! -d $CMSFOLDER ]; then
+    echo "You need to define the folder where the CMSSW environment is located"
+    exit 1
+else
+    echo "CMSSW environment is located at $CMSFOLDER"
+fi
+
+rm Execute
+rm -rf ../../CommonCode/binary/
+rm -rf ../../CommonCode/library/
+rm MergedOutput.root
+rm -rf Output
+rm SkimReco.root
+rm list.txt
+rm -rf output
+rm *.txt*
+rm SkimReco.root
+rm .DS_Store
+
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+cd $CMSFOLDER
+cmsenv
+echo "CMSSW environment is set up"
+
+cd $WORKFOLDER
+cd ../../
+source SetupAnalysis.sh
+cd CommonCode/
+make
+cd ..
+cd $WORKFOLDER
+make
+rm skim*.root

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/getXrdSize.sh
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/getXrdSize.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Define specific xrootd server for faster processing
+XROOTD_SERVER="root://xrootd5.cmsaf.mit.edu"
+REMOTE_DIR="/store/user/jdlang/run3_2024PromptRecoSkims_HIForward_20241210/"
+
+# Make dated list of all files in parent dir
+DATE=$(date +%Y%m%d)
+FILE_LIST="run3_2024PromptReco_${DATE}.txt"
+rm $FILE_LIST
+xrdfs $XROOTD_SERVER ls -R -l $REMOTE_DIR >> $FILE_LIST
+if [ -z "$FILE_LIST" ]; then
+    echo "No files found in the remote directory: $REMOTE_DIR"
+    exit 1
+fi
+# Temp file for valid paths
+temp_file=$(mktemp)
+# Keep only paths ending with '.root'
+while IFS= read -r line; do
+  if [[ "$line" =~ \.root$ ]]; then
+    echo "$line" >> "$temp_file"
+  fi
+done < $FILE_LIST
+# Replace the original file with the temp file
+mv "$temp_file" "$FILE_LIST"
+
+# Calculate the total size, file by file
+TOTAL_SIZE=0
+LINE_COUNTER=0
+while read -r LINE; do
+    # Extract the size field (4th column from `xrdfs ls -R -l`)
+    SIZE=$(echo "$LINE" | awk '{print $4}')
+    if [[ "$SIZE" =~ ^[0-9]+$ ]]; then
+      TOTAL_SIZE=$((TOTAL_SIZE + SIZE))
+    fi
+    if ! (( $LINE_COUNTER % 1000 )); then
+      echo "$LINE_COUNTER: $TOTAL_SIZE"
+    fi
+    LINE_COUNTER=$((LINE_COUNTER + 1))
+done < $FILE_LIST
+
+# Convert to human-readable format
+HUMAN_SIZE=$(numfmt --to=iec-i --suffix=B $TOTAL_SIZE)
+echo "Total size of the folder $REMOTE_DIR: $HUMAN_SIZE ($TOTAL_SIZE)"

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/include/DmesonSelection.h
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/include/DmesonSelection.h
@@ -1,0 +1,59 @@
+bool DmesonSelectionPrelim23(DzeroTreeMessenger& MDzero, int iD) {
+  const int nPtBinsOpt = 3;
+  const int nYBinsOpt = 4;
+
+  float Dchi2clCutValue[nPtBinsOpt][nYBinsOpt] = {
+    {0.1, 0.1, 0.1, 0.1}, {0.1, 0.1, 0.1, 0.1}, {0.1, 0.1, 0.1, 0.1}};
+  float DalphaCutValue[nPtBinsOpt][nYBinsOpt] = {
+    {0.2, 0.4, 0.4, 0.2}, {0.25, 0.35, 0.35, 0.25}, {0.25, 0.4, 0.4, 0.25}};
+  float DdthetaCutValue[nPtBinsOpt][nYBinsOpt] = {
+    {0.3, 0.5, 0.5, 0.3}, {0.3, 0.3, 0.3, 0.3}, {0.3, 0.3, 0.3, 0.3}};
+  float DsvpvSigCutValue[nPtBinsOpt][nYBinsOpt] = {
+    {2.5, 2.5, 2.5, 2.5}, {3.5, 3.5, 3.5, 3.5}, {3.5, 3.5, 3.5, 3.5}};
+
+  const int nPtBins = 3;
+  const int nYBins = 4;
+  float ptBins[nPtBins + 1] = {2, 5, 8, 12};
+  float yBins[nYBins + 1] = {-2.0, -1.0, 0.0, 1.0, 2.0};
+
+  float pt = MDzero.Dpt[iD];
+  float y = MDzero.Dy[iD];
+    
+  // Determine pt and y bin indices
+  int ptBin = -1;
+  int yBin = -1;
+  for (int i = 0; i < nPtBins; ++i) {
+    if (pt >= ptBins[i] && pt < ptBins[i + 1]) {
+      ptBin = i;
+      break;
+    }
+  }
+  for (int j = 0; j < nYBins; ++j) {
+    if (y >= yBins[j] && y < yBins[j + 1]) {
+      yBin = j;
+      break;
+    }
+  }
+
+  // Check if the pt and y bins were found
+  if (ptBin == -1 || yBin == -1) {
+    //cerr << "Error! No pt bin and/or y bin found for D meson selection. "
+    // << "pt = " << pt << ", y = " << y
+    // << ". Please check if the pt or y values fall within the defined bin ranges." << endl;
+    return 0;
+  }
+
+  // Apply cuts for the identified ptBin and yBin
+  bool pass = (MDzero.Dchi2cl[iD] >= Dchi2clCutValue[ptBin][yBin]) &&
+              (MDzero.Dalpha[iD] <= DalphaCutValue[ptBin][yBin]) &&
+              (MDzero.Ddtheta[iD] <= DdthetaCutValue[ptBin][yBin]) &&
+              (MDzero.DsvpvDistance[iD] / MDzero.DsvpvDisErr[iD] >= DsvpvSigCutValue[ptBin][yBin]);
+
+  return pass;
+}
+
+bool DmesonSelectionSkimPrelim23(DzeroTreeMessenger& MDzero, int iD) {
+  float pt = MDzero.Dpt[iD];
+  if (pt < 2.) return false;
+  return true;
+}

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/makefile
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/makefile
@@ -1,0 +1,29 @@
+default: Execute
+
+TestRun: Execute
+	./Execute --Input HiForestMiniAOD_1.root \
+                  --Output SkimReco_UPCPbPb23_388000_HIForward0_1.root --Year 2024 --IsData true \
+                  --ApplyTriggerRejection false \
+                  --ApplyEventRejection false \
+                  --ApplyZDCGapRejection false \
+                  --ApplyDRejection false \
+                  --PFTree particleFlowAnalyser/pftree
+
+TestRunBase: Execute
+	./Execute --Input HiForestMiniAOD_1.root \
+                  --Output SkimReco_UPCPbPb23_388000_HIForward0_1.root --Year 2024 --IsData true \
+                  --ApplyTriggerRejection false \
+                  --ApplyEventRejection false \
+                  --ApplyZDCGapRejection false \
+                  --ApplyDRejection false \
+                  --PFTree particleFlowAnalyser/pftree
+
+Execute: ReduceForest.cpp
+	CGO_ENABLED=0
+	g++ ReduceForest.cpp -o Execute \
+		-Wl,-Bstatic -lpthread -lc \
+		-Wl,-Bdynamic `root-config --cflags --libs` \
+		-I$(ProjectBase)/CommonCode/include $(ProjectBase)/CommonCode/library/Messenger.o
+#	g++ ReduceForest.cpp -o Execute \
+#		`root-config --cflags --glibs` \
+#		-I$(ProjectBase)/CommonCode/include $(ProjectBase)/CommonCode/library/Messenger.o

--- a/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/makefile
+++ b/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/makefile
@@ -20,10 +20,10 @@ TestRunBase: Execute
 
 Execute: ReduceForest.cpp
 	CGO_ENABLED=0
-	g++ ReduceForest.cpp -o Execute \
-		-Wl,-Bstatic -lpthread -lc \
-		-Wl,-Bdynamic `root-config --cflags --libs` \
-		-I$(ProjectBase)/CommonCode/include $(ProjectBase)/CommonCode/library/Messenger.o
 #	g++ ReduceForest.cpp -o Execute \
-#		`root-config --cflags --glibs` \
+#		-Wl,-Bstatic -lpthread -lc \
+#		-Wl,-Bdynamic `root-config --cflags --libs` \
 #		-I$(ProjectBase)/CommonCode/include $(ProjectBase)/CommonCode/library/Messenger.o
+	g++ ReduceForest.cpp -o Execute \
+		`root-config --cflags --glibs` \
+		-I$(ProjectBase)/CommonCode/include $(ProjectBase)/CommonCode/library/Messenger.o


### PR DESCRIPTION
Enables skimming on Condor from MIT Submit. To use:
1. Source cvmfs
2. Set an enviroment with root (e.g. cmsenv from a CMSSW directory)
3. Enable your voms proxy (ideally with a duration of several days)
4.cd to MITHIGAnalysis2024/SampleGeneration/20241204_CondorForestReducer_DzeroUPC/ and run with `bash RunSkimCondor.sh`

Input and output locations can be changed by editing RunSkimCondor.sh. Each job processes the forest files for one run and PD (e.g. 20 runs currently forested with 20 PDs each is 400 jobs).