### PR TITLE
muonAnalyzer variables (a.k.a., "singleMu tree")

### DIFF
--- a/CommonCode/include/Messenger.h
+++ b/CommonCode/include/Messenger.h
@@ -22,12 +22,14 @@ class GGTreeMessenger;
 class RhoTreeMessenger;
 class SkimTreeMessenger;
 class JetTreeMessenger;
+class CharmHadronTreeMessenger;
 class GenParticleTreeMessenger;
 class PFTreeMessenger;
 class TriggerTreeMessenger;
 class TriggerObjectTreeMessenger;
 class TrackTreeMessenger;
 class MuTreeMessenger;
+class MuAnaTreeMessenger;
 class PbPbTrackTreeMessenger;
 class PbPbUPCTrackTreeMessenger;
 class ZDCTreeMessenger;
@@ -170,6 +172,21 @@ public:
    float JetCSVV2N[JETCOUNTMAX];
    float JetCSVV1P[JETCOUNTMAX];
    float JetCSVV2P[JETCOUNTMAX];
+   float JetUParT[JETCOUNTMAX];
+   float JetUParT_u[JETCOUNTMAX];
+   float JetUParT_d[JETCOUNTMAX];
+   float JetUParT_s[JETCOUNTMAX];
+   float JetUParT_c[JETCOUNTMAX];
+   float JetUParT_b[JETCOUNTMAX];
+   float JetUParT_g[JETCOUNTMAX];
+   float JetUParT_bb[JETCOUNTMAX];
+   float JetUParT_tau[JETCOUNTMAX];
+   float JetUParT_lepb[JETCOUNTMAX];
+   float JetUParT_ele[JETCOUNTMAX];
+   float JetUParT_mu[JETCOUNTMAX];
+   float JetUParT_ptnu[JETCOUNTMAX];
+   float JetUParT_ptcorr[JETCOUNTMAX];
+
    std::vector<std::vector<float> > *JetSubJetPT;
    std::vector<std::vector<float> > *JetSubJetEta;
    std::vector<std::vector<float> > *JetSubJetPhi;
@@ -216,13 +233,14 @@ public:
    int JetPFNEM[JETCOUNTMAX];
    int JetPFMUM[JETCOUNTMAX];
 public:
-   JetTreeMessenger(TFile &File, std::string TreeName = "akCs4PFJetAnalyzer/t");
-   JetTreeMessenger(TFile *File, std::string TreeName = "akCs4PFJetAnalyzer/t");
+   JetTreeMessenger(TFile &File, std::string TreeName = "akCs0PFJetAnalyzer/t");
+   JetTreeMessenger(TFile *File, std::string TreeName = "akCs0PFJetAnalyzer/t");
    JetTreeMessenger(TTree *JetTree);
    bool Initialize(TTree *JetTree);
    bool Initialize();
    bool GetEntry(int iEntry);
 };
+
 
 class GenParticleTreeMessenger
 {
@@ -434,6 +452,28 @@ public:
    bool GetEntry(int iEntry);
 };
 
+class MuAnaTreeMessenger
+{
+public:
+   TTree *Tree;
+   std::vector<float> *MuPT = nullptr;
+   std::vector<float> *MuEta = nullptr;
+   std::vector<float> *MuPhi = nullptr;
+   std::vector<float> *MuDxy = nullptr;
+   std::vector<float> *MuDxyError = nullptr;
+   std::vector<float> *MuDz = nullptr;
+   std::vector<float> *MuDzError = nullptr;
+   std::vector<int> *MuCharge = nullptr;
+public:
+   MuAnaTreeMessenger(TFile &File, std::string TreeName = "muonAnalyzer/MuonTree");
+   MuAnaTreeMessenger(TFile *File, std::string TreeName = "muonAnalyzer/MuonTree");
+   MuAnaTreeMessenger(TTree *MuAnaTree);
+   bool Initialize(TTree *MuAnaTree);
+   bool Initialize();
+   bool GetEntry(int iEntry);
+   bool DimuonPassTightCut(int index);
+};
+
 class MuTreeMessenger
 {
 public:
@@ -517,6 +557,7 @@ public:
    float DiDxy2[MUMAX];
    float DiDz1[MUMAX];
    float DiDz2[MUMAX];
+//   float DiDxy1Error[MUMAX];
 public:
    MuTreeMessenger(TFile &File, std::string TreeName = "hltMuTree/HLTMuTree");
    MuTreeMessenger(TFile *File, std::string TreeName = "hltMuTree/HLTMuTree");
@@ -833,6 +874,24 @@ public:
    std::vector<int> *MJTHadronFlavor;
    std::vector<int> *MJTNcHad;
    std::vector<int> *MJTNbHad;
+   //variables from muonAnalyzer/MuonTree
+   std::vector<float> *singleMuEta1;
+   std::vector<float> *singleMuPhi1;
+   std::vector<float> *singleMuPt1;
+   std::vector<float> *singleMuDxy1;
+   std::vector<float> *singleMuDxyError1;
+   std::vector<float> *singleMuDz1;
+   std::vector<float> *singleMuDzError1;
+   std::vector<int> *singleMuCharge1;
+   std::vector<float> *singleMuEta2;
+   std::vector<float> *singleMuPhi2;
+   std::vector<float> *singleMuPt2;
+   std::vector<float> *singleMuDxy2;
+   std::vector<float> *singleMuDxyError2;
+   std::vector<float> *singleMuDz2;
+   std::vector<float> *singleMuDzError2;
+   std::vector<int> *singleMuCharge2;
+
 private:
    bool WriteMode;
    bool Initialized;

--- a/CommonCode/source/Messenger.cpp
+++ b/CommonCode/source/Messenger.cpp
@@ -3156,6 +3156,22 @@ MuMuJetMessenger::~MuMuJetMessenger()
       delete MJTHadronFlavor;
       delete MJTNcHad;
       delete MJTNbHad;
+      delete singleMuEta1;
+      delete singleMuPhi1;
+      delete singleMuPt1;
+      delete singleMuDxy1;
+      delete singleMuDxyError1;
+      delete singleMuDz1;
+      delete singleMuDzError1;
+      delete singleMuCharge1;
+      delete singleMuEta2;
+      delete singleMuPhi2;
+      delete singleMuPt2;
+      delete singleMuDxy2;
+      delete singleMuDxyError2;
+      delete singleMuDz2;
+      delete singleMuDzError2;
+      delete singleMuCharge2;
    }
 }
 
@@ -3196,6 +3212,22 @@ bool MuMuJetMessenger::Initialize()
    MJTHadronFlavor = nullptr;
    MJTNcHad = nullptr;
    MJTNbHad = nullptr;
+   singleMuEta1 = nullptr;
+   singleMuPhi1 = nullptr;
+   singleMuPt1 = nullptr;
+   singleMuDxy1 = nullptr;
+   singleMuDxyError1 = nullptr;
+   singleMuDz1 = nullptr;
+   singleMuDzError1 = nullptr;
+   singleMuCharge1 = nullptr;
+   singleMuEta2 = nullptr;
+   singleMuPhi2 = nullptr;
+   singleMuPt2 = nullptr;
+   singleMuDxy2 = nullptr;
+   singleMuDxyError2 = nullptr;
+   singleMuDz2 = nullptr;
+   singleMuDzError2 = nullptr;
+   singleMuCharge2 = nullptr;
 
    Tree->SetBranchAddress("Run", &Run);
    Tree->SetBranchAddress("Event", &Event);
@@ -3235,6 +3267,22 @@ bool MuMuJetMessenger::Initialize()
    Tree->SetBranchAddress("MJTHadronFlavor", &MJTHadronFlavor);
    Tree->SetBranchAddress("MJTNcHad", &MJTNcHad);
    Tree->SetBranchAddress("MJTNbHad", &MJTNbHad);
+   Tree->SetBranchAddress("singleMuEta1", &singleMuEta1);
+   Tree->SetBranchAddress("singleMuPhi1", &singleMuPhi1);
+   Tree->SetBranchAddress("singleMuPt1", &singleMuPt1);
+   Tree->SetBranchAddress("singleMuDxy1", &singleMuDxy1);
+   Tree->SetBranchAddress("singleMuDxyError1", &singleMuDxyError1);
+   Tree->SetBranchAddress("singleMuDz1", &singleMuDz1);
+   Tree->SetBranchAddress("singleMuDzError1", &singleMuDzError1);
+   Tree->SetBranchAddress("singleMuCharge1", &singleMuCharge1);
+   Tree->SetBranchAddress("singleMuEta2", &singleMuEta2);
+   Tree->SetBranchAddress("singleMuPhi2", &singleMuPhi2);
+   Tree->SetBranchAddress("singleMuPt2", &singleMuPt2);
+   Tree->SetBranchAddress("singleMuDxy2", &singleMuDxy2);
+   Tree->SetBranchAddress("singleMuDxyError2", &singleMuDxyError2);
+   Tree->SetBranchAddress("singleMuDz2", &singleMuDz2);
+   Tree->SetBranchAddress("singleMuDzError2", &singleMuDzError2);
+   Tree->SetBranchAddress("singleMuCharge2", &singleMuCharge2);
    return true;
 }
 
@@ -3288,6 +3336,22 @@ bool MuMuJetMessenger::SetBranch(TTree *T)
    MJTHadronFlavor = new std::vector<int>();
    MJTNcHad = new std::vector<int>();
    MJTNbHad = new std::vector<int>();
+   singleMuEta1 = new std::vector<float>();
+   singleMuPhi1 = new std::vector<float>();
+   singleMuPt1 = new std::vector<float>();
+   singleMuDxy1 = new std::vector<float>();
+   singleMuDxyError1 = new std::vector<float>();
+   singleMuDz1 = new std::vector<float>();
+   singleMuDzError1 = new std::vector<float>();
+   singleMuCharge1 = new std::vector<int>();
+   singleMuEta2 = new std::vector<float>();
+   singleMuPhi2 = new std::vector<float>();
+   singleMuPt2 = new std::vector<float>();
+   singleMuDxy2 = new std::vector<float>();
+   singleMuDxyError2 = new std::vector<float>();
+   singleMuDz2 = new std::vector<float>();
+   singleMuDzError2 = new std::vector<float>();
+   singleMuCharge2 = new std::vector<int>();
 
    Tree = T;
 
@@ -3329,6 +3393,22 @@ bool MuMuJetMessenger::SetBranch(TTree *T)
    Tree->Branch("MJTHadronFlavor", &MJTHadronFlavor);
    Tree->Branch("MJTNcHad", &MJTNcHad);
    Tree->Branch("MJTNbHad", &MJTNbHad);
+   Tree->Branch("singleMuEta1", &singleMuEta1);
+   Tree->Branch("singleMuPhi1", &singleMuPhi1);
+   Tree->Branch("singleMuPt1", &singleMuPt1);
+   Tree->Branch("singleMuDxy1", &singleMuDxy1);
+   Tree->Branch("singleMuDxyError1", &singleMuDxyError1);
+   Tree->Branch("singleMuDz1", &singleMuDz1);
+   Tree->Branch("singleMuDzError1", &singleMuDzError1);
+   Tree->Branch("singleMuCharge1",&singleMuCharge1);
+   Tree->Branch("singleMuEta2", &singleMuEta2);
+   Tree->Branch("singleMuPhi2", &singleMuPhi2);
+   Tree->Branch("singleMuPt2", &singleMuPt2);
+   Tree->Branch("singleMuDxy2", &singleMuDxy2);
+   Tree->Branch("singleMuDxyError2", &singleMuDxyError2);
+   Tree->Branch("singleMuDz2", &singleMuDz2);
+   Tree->Branch("singleMuDzError2", &singleMuDzError2);
+   Tree->Branch("singleMuCharge2",&singleMuCharge2);
    return true;
 }
 
@@ -3375,7 +3455,24 @@ void MuMuJetMessenger::Clear()
    MJTHadronFlavor->clear();
    MJTNcHad->clear();
    MJTNbHad->clear();
+   singleMuPhi1->clear();
+   singleMuEta1->clear();
+   singleMuPt1->clear();
+   singleMuDxy1->clear();
+   singleMuDxyError1->clear();
+   singleMuDz1->clear();
+   singleMuDzError1->clear();
+   singleMuCharge1->clear();
+   singleMuPhi2->clear();
+   singleMuEta2->clear();
+   singleMuPt2->clear();
+   singleMuDxy2->clear();
+   singleMuDxyError2->clear();
+   singleMuDz2->clear();
+   singleMuDzError2->clear();
+   singleMuCharge2->clear();
 }
+
 
 void MuMuJetMessenger::CopyNonTrack(MuMuJetMessenger &M)
 {
@@ -3419,6 +3516,24 @@ void MuMuJetMessenger::CopyNonTrack(MuMuJetMessenger &M)
    if(MJTHadronFlavor != nullptr && M.MJTHadronFlavor != nullptr)   *MJTHadronFlavor = *(M.MJTHadronFlavor);
    if(MJTNcHad != nullptr && M.MJTNcHad != nullptr)   *MJTNcHad = *(M.MJTNcHad);
    if(MJTNbHad != nullptr && M.MJTNbHad != nullptr)   *MJTNbHad = *(M.MJTNbHad);
+   if(singleMuEta1 != nullptr && M.singleMuEta1 != nullptr)   *singleMuEta1 = *(M.singleMuEta1);
+   if(singleMuPhi1 != nullptr && M.singleMuPhi1 != nullptr)   *singleMuPhi1 = *(M.singleMuPhi1);
+   if(singleMuPt1 != nullptr && M.singleMuPt1 != nullptr )   *singleMuPt1 = *(M.singleMuPt1);
+   if(singleMuDxy1 != nullptr && M.singleMuDxy1 != nullptr)   *singleMuDxy1 = *(M.singleMuDxy1);
+   if(singleMuDxyError1 != nullptr && M.singleMuDxyError1 != nullptr)   *singleMuDxyError1 = *(M.singleMuDxyError1);
+   if(singleMuDz1 != nullptr && M.singleMuDz1 != nullptr)   *singleMuDz1 = *(M.singleMuDz1);
+   if(singleMuDzError1 != nullptr && M.singleMuDzError1 != nullptr)   *singleMuDzError1 = *(M.singleMuDzError1);
+   if(singleMuCharge1 != nullptr && M.singleMuCharge1 != nullptr)   *singleMuCharge1 = *(M.singleMuCharge1);
+   if(singleMuEta2 != nullptr && M.singleMuEta2 != nullptr)   *singleMuEta2 = *(M.singleMuEta2);
+   if(singleMuPhi2 != nullptr && M.singleMuPhi2 != nullptr)   *singleMuPhi2 = *(M.singleMuPhi2);
+   if(singleMuPt2 != nullptr && M.singleMuPt2 != nullptr )   *singleMuPt2 = *(M.singleMuPt2);
+   if(singleMuDxy2 != nullptr && M.singleMuDxy2 != nullptr)   *singleMuDxy2 = *(M.singleMuDxy2);
+   if(singleMuDxyError2 != nullptr && M.singleMuDxyError2 != nullptr)   *singleMuDxyError2 = *(M.singleMuDxyError2);
+   if(singleMuDz2 != nullptr && M.singleMuDz2 != nullptr)   *singleMuDz1 = *(M.singleMuDz2);
+   if(singleMuDzError2 != nullptr && M.singleMuDzError2 != nullptr)   *singleMuDzError2 = *(M.singleMuDzError2);
+   if(singleMuCharge2 != nullptr && M.singleMuCharge2 != nullptr)   *singleMuCharge2 = *(M.singleMuCharge2);
+
+
 }
 
 bool MuMuJetMessenger::FillEntry()
@@ -3435,4 +3550,66 @@ bool MuMuJetMessenger::FillEntry()
    Clear();
 
    return true;
+}
+
+
+MuAnaTreeMessenger::MuAnaTreeMessenger(TFile &File, std::string TreeName)
+{
+   Tree = (TTree *)File.Get(TreeName.c_str());
+   Initialize();
+}
+
+MuAnaTreeMessenger::MuAnaTreeMessenger(TFile *File, std::string TreeName)
+{
+   if(File != nullptr)
+      Tree = (TTree *)File->Get(TreeName.c_str());
+   else
+      Tree = nullptr;
+   Initialize();
+}
+
+MuAnaTreeMessenger::MuAnaTreeMessenger(TTree *MuAnaTree)
+{
+   Initialize(MuAnaTree);
+}
+
+bool MuAnaTreeMessenger::Initialize(TTree *MuAnaTree)
+{
+   Tree = MuAnaTree;
+   return Initialize();
+}
+
+bool MuAnaTreeMessenger::Initialize()
+{
+   if(Tree == nullptr)
+      return false;
+
+   Tree->SetBranchAddress("recoPt", &MuPT);
+   Tree->SetBranchAddress("recoEta", &MuEta);
+   Tree->SetBranchAddress("recoPhi", &MuPhi);
+   Tree->SetBranchAddress("globalDxy", &MuDxy);
+   Tree->SetBranchAddress("globalDxyErr", &MuDxyError);
+   Tree->SetBranchAddress("globalDz", &MuDz);
+   Tree->SetBranchAddress("globalDzErr", &MuDzError);
+   Tree->SetBranchAddress("recoCharge", &MuCharge);
+
+
+   return true;
+}
+
+bool MuAnaTreeMessenger::GetEntry(int iEntry)
+{
+   if(Tree == nullptr)
+      return false;
+
+   Tree->GetEntry(iEntry);
+   return true;
+}
+
+bool MuAnaTreeMessenger::DimuonPassTightCut(int index)
+{
+
+   bool TightCut = false;
+
+   return TightCut;
 }

--- a/SampleGeneration/20241025_ForestReducer_MuMuJet/ReduceForest.cpp
+++ b/SampleGeneration/20241025_ForestReducer_MuMuJet/ReduceForest.cpp
@@ -53,6 +53,7 @@ int main(int argc, char *argv[]) {
     PbPbTrackTreeMessenger MTrack(InputFile);
     GenParticleTreeMessenger MGen(InputFile);
     PFTreeMessenger MPF(InputFile, PFTreeName);
+    MuAnaTreeMessenger MMuAna(InputFile); //muons from muonAnalyzer, the "singleMu" tree
     MuTreeMessenger MMu(InputFile);
     SkimTreeMessenger MSkim(InputFile);
     TriggerTreeMessenger MTrigger(InputFile);
@@ -83,6 +84,7 @@ int main(int argc, char *argv[]) {
       MSkim.GetEntry(iE);
       MTrigger.GetEntry(iE);
       MJet.GetEntry(iE);
+      MMuAna.GetEntry(iE);
       MMuMuJet.Clear();
 
       ////////////////////////////////////////
@@ -197,6 +199,19 @@ int main(int argc, char *argv[]) {
         // variable to identify the highest pt dimuon pair
         float maxmumuPt = 0.;
         int maxMuMuIndex = -1;
+	
+	 //for loop for printing out singleMu tree content;
+	 //
+/*	 for (int i = 0; i < MMuAna.MuPT->size(); i++)
+	{
+		cout << MMuAna.MuPT->at(i) << endl;
+		cout << MMuAna.MuPhi->at(i) << endl;
+		cout << MMuAna.MuEta->at(i) << endl;
+		cout << MMuAna.MuCharge->at(i) << endl;
+		cout << MMuAna.MuDxy->at(i) << endl;
+		cout << MMuAna.MuDxyError->at(i) << endl;
+	}
+*/
 
         for (int ipair = 0; ipair < MMu.NDi; ipair++) {
           if (MMu.DiCharge1[ipair] == MMu.DiCharge2[ipair])
@@ -215,10 +230,10 @@ int main(int argc, char *argv[]) {
             continue;
           if (deltaR(MJet.JetEta[ijet], MJet.JetPhi[ijet], MMu.DiEta2[ipair], MMu.DiPhi2[ipair]) > 0.3)
             continue;
-          //if (fabs(MMu.DiDxy1[ipair]) < 0.01)
-          //  continue;
-          //if (fabs(MMu.DiDxy2[ipair]) < 0.01)
-          //  continue;
+          if (fabs(MMu.DiDxy1[ipair]) < 0.01)
+            continue;
+          if (fabs(MMu.DiDxy2[ipair]) < 0.01)
+            continue;
           // build dimuon TLorentzVector
           TLorentzVector Mu1, Mu2;
           Mu1.SetPtEtaPhiM(MMu.DiPT1[ipair], MMu.DiEta1[ipair], MMu.DiPhi1[ipair], M_MU);


### PR DESCRIPTION
This PR modifies the Messenger.cpp & Messenger.h to add the muonAnalyzer trees (a.k.a. "singleMu" trees), complementary to the hltMuTree (a.k.a., "dimuon" tree).

Skimmer still relies on the hltMuTree (as discussed privately), lines that are meant to be used as an example for fetching the info from the singleMu trees are currently commented out. Tested with latest MC forest.