### PR TITLE
New scripts to run forest reducer on SubMIT with Condor

### DIFF
--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/CopyToT2.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/CopyToT2.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+ANALYSIS_DIR='MITHIGAnalysis2024'
+SKIM_DIR='20241214_ForestReducer_DzeroUPC_2023OldReco'
+
+# Remove existing files on T2
+xrdfs root://xrootd.cmsaf.mit.edu/ ls -R /store/user/$USER/$ANALYSIS_DIR/ >> temp_xrd_delete.txt
+while read -r LINE; do
+  if [[ "$LINE" =~ \.*$ ]]; then
+    xrdfs root://xrootd.cmsaf.mit.edu/ rm $LINE
+  fi
+done < temp_xrd_delete.txt
+rm temp_xrd_delete.txt
+xrdfs root://xrootd.cmsaf.mit.edu/ rmdir /store/user/$USER/$ANALYSIS_DIR/
+
+# Copy over current state of Condor dir
+xrdfs root://xrootd.cmsaf.mit.edu/ mkdir -p /store/user/$USER/$ANALYSIS_DIR/SampleGeneration/$SKIM_DIR
+xrdcp -r -f ../../CommonCode    root://xrootd.cmsaf.mit.edu//store/user/$USER/$ANALYSIS_DIR/
+xrdcp -f ../../SetupAnalysis.sh root://xrootd.cmsaf.mit.edu//store/user/$USER/$ANALYSIS_DIR/
+xrdcp -r -f include       	root://xrootd.cmsaf.mit.edu//store/user/$USER/$ANALYSIS_DIR/SampleGeneration/$SKIM_DIR/
+xrdcp -f ReduceForest.cpp 	root://xrootd.cmsaf.mit.edu//store/user/$USER/$ANALYSIS_DIR/SampleGeneration/$SKIM_DIR/
+xrdcp -f makefile         	root://xrootd.cmsaf.mit.edu//store/user/$USER/$ANALYSIS_DIR/SampleGeneration/$SKIM_DIR/

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/MakeCondorSkim.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/MakeCondorSkim.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# THIS CONFIG IS FOR CMSSW_13_2_4 ONLY
+
+BASENAME=$1
+JOB_LIST=$2
+CONFIG_DIR=$3
+XROOTD_SERVER=$4
+OUTPUT_PATH=$5
+PROXYFILE=$6
+
+ANALYSIS_SUBDIR='SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/'
+SCRIPT="${CONFIG_DIR}/${BASENAME}_script.sh"
+CONFIG="${CONFIG_DIR}/${BASENAME}_config.condor"
+
+JOB_LIST_NAME="${JOB_LIST##*/}"
+PROXYFILE_NAME="${PROXYFILE##*/}"
+
+
+
+# MAKE CONDOR SCRIPT ==========================================================
+rm $SCRIPT
+sleep 0.5
+cat > $SCRIPT <<EOF1
+#!/bin/bash
+
+CLUSTER=\$1
+PROC=\$2
+
+# OS config checks
+echo ""
+echo ">>> Host info"
+hostname
+uname -a
+echo ""
+echo ">>> VOMS info"
+unset  X509_USER_KEY
+export X509_USER_KEY=$PROXYFILE_NAME
+voms-proxy-info
+
+# Setup
+echo ""
+echo ">>> Setting up CMSSW_13_2_4"
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+wait
+cmsrel CMSSW_13_2_4
+wait
+cd CMSSW_13_2_4/src/
+cmsenv
+wait
+cd ../../
+which root
+which hadd
+echo ""
+echo ">>> Setting up directory"
+while ! [ -d "MITHIGAnalysis2024" ]; do
+  xrdcp -r -f --notlsok root://xrootd.cmsaf.mit.edu//store/user/$USER/MITHIGAnalysis2024 .
+done
+cd MITHIGAnalysis2024
+source SetupAnalysis.sh
+wait
+cd CommonCode/
+make
+wait
+cd ../$ANALYSIS_SUBDIR
+cp ../../../$JOB_LIST_NAME .
+cp ../../../$PROXYFILE_NAME .
+ls -l
+echo ""
+echo ">>> Compiling skimmer"
+# Must manually compile to avoid error from missing test file
+g++ ReduceForest.cpp -o Execute \\
+  `root-config --cflags --glibs` \\
+  -I\$ProjectBase/CommonCode/include \$ProjectBase/CommonCode/library/Messenger.o
+wait
+sleep 1
+if ! [ -f "Execute" ]; then
+  echo "ERROR: Unable to compile executable!"
+  exit 2
+fi
+
+# Skimming
+echo ""
+echo ">>> Running skimmer"
+mkdir -p "output"
+COUNTER=0
+while read -r ROOT_IN_T2; do
+  ROOT_IN_LOCAL="forest_\${COUNTER}.root"
+  ROOT_OUT="output/${BASENAME}_\${COUNTER}.root"
+  xrdcp -f -N -s --notlsok \$ROOT_IN_T2 \$ROOT_IN_LOCAL
+  wait
+  if ! [ -f "\$ROOT_IN_LOCAL" ]; then
+    echo "--- ERROR! Missing root file: \$ROOT_IN_LOCAL"
+    exit 1
+  fi
+  echo "--- Processing file: \$ROOT_IN_LOCAL"
+  ./Execute --Input \$ROOT_IN_LOCAL \\
+    --Output \$ROOT_OUT \\
+    --Year 2023 \\
+    --ApplyTriggerRejection 2 \\
+    --ApplyEventRejection true \\
+    --ApplyZDCGapRejection true \\
+    --ApplyDRejection 2 \\
+    --ZDCMinus1nThreshold 1000 \\
+    --ZDCPlus1nThreshold 1100 \\
+    --IsData true \\
+    --PFTree particleFlowAnalyser/pftree &
+  wait
+  rm \$ROOT_IN_LOCAL
+  ((COUNTER++))
+done < $JOB_LIST_NAME
+wait
+echo ""
+echo ">>> Completed \$COUNTER jobs!"
+
+# Merge and transfer
+echo ""
+echo ">>> Merging root files"
+hadd -ff ${BASENAME}_merged.root output/${BASENAME}_*.root
+wait
+echo ""
+echo ">>> Transferring merged root file to T2"
+xrdcp -f --notlsok ${BASENAME}_merged.root ${XROOTD_SERVER}${OUTPUT_PATH}
+wait
+echo ""
+echo ">>> Done!"
+
+EOF1
+# -----------------------------------------------------------------------------
+echo "Made script: $SCRIPT"
+
+
+
+# MAKE CONDOR CONFIG ==========================================================
+rm $CONFIG
+sleep 0.5
+cat > $CONFIG <<EOF2
+### Job settings
+Universe                = vanilla
+request_disk            = 6GB
+request_memory          = 3GB
+initialdir              = $PWD/
+executable              = $PWD/$SCRIPT
+arguments               = \$(ClusterId) \$(ProcId)
+use_x509userproxy       = True
+x509userproxy           = $PROXYFILE
++AccountingGroup        = "analysis.$USER"
+max_retries             = 1
+
+### File transfer
+should_transfer_files   = YES
+transfer_input_files    = $JOB_LIST
+MAX_TRANSFER_INPUT_MB   = 400
+#on_exit_remove          = (ExitBySignal == False) && (ExitCode == 0)
+
+### Logging
+notification            = Error
+output                  = ${CONFIG_DIR}/${BASENAME}_out_\$(ClusterId)_\$(ProcId).txt
+error                   = ${CONFIG_DIR}/${BASENAME}_err_\$(ClusterId)_\$(ProcId).txt
+log                     = ${CONFIG_DIR}/${BASENAME}_log_\$(ClusterId)_\$(ProcId).txt
+
+### Server settings
+MY.WantOS               = "el9"
+Requirements            = ( (OpSysAndVer =?= "AlmaLinux9" || OpSysAndVer =?= "CentOS9") && (Arch =?= "X86_64") && (BOSCOCluster =!= "t3serv008.mit.edu") && (BOSCOCluster =!= "ce03.cmsaf.mit.edu") && (BOSCOCluster =!= "eofe8.mit.edu") )
++SingularityImage       = "/cvmfs/unpacked.cern.ch/registry.hub.docker.com/cmssw/el9:x86_64-d20241130"
++DESIRED_Sites          = "mit_tier2,mit_tier3,T2_AT_Vienna,T2_BE_IIHE,T2_BE_UCL,T2_BR_SPRACE,T2_BR_UERJ,T2_CH_CERN,T2_CH_CERN_AI,T2_CH_CERN_HLT,T2_CH_CERN_Wigner,T2_CH_CSCS,T2_CH_CSCS_HPC,T2_CN_Beijing,T2_DE_DESY,T2_DE_RWTH,T2_EE_Estonia,T2_ES_CIEMAT,T2_ES_IFCA,T2_FI_HIP,T2_FR_CCIN2P3,T2_FR_GRIF_IRFU,T2_FR_GRIF_LLR,T2_FR_IPHC,T2_GR_Ioannina,T2_HU_Budapest,T2_IN_TIFR,T2_IT_Bari,T2_IT_Legnaro,T2_IT_Pisa,T2_IT_Rome,T2_KR_KISTI,T2_MY_SIFIR,T2_MY_UPM_BIRUNI,T2_PK_NCP,T2_PL_Swierk,T2_PL_Warsaw,T2_PT_NCG_Lisbon,T2_RU_IHEP,T2_RU_INR,T2_RU_ITEP,T2_RU_JINR,T2_RU_PNPI,T2_RU_SINP,T2_TH_CUNSTDA,T2_TR_METU,T2_TW_NCHC,T2_UA_KIPT,T2_UK_London_IC,T2_UK_SGrid_Bristol,T2_UK_SGrid_RALPP,T2_US_Caltech,T2_US_Florida,T2_US_Nebraska,T2_US_Purdue,T2_US_UCSD,T2_US_Vanderbilt,T2_US_Wisconsin,T3_CH_CERN_CAF,T3_CH_CERN_DOMA,T3_CH_CERN_HelixNebula,T3_CH_CERN_HelixNebula_REHA,T3_CH_CMSAtHome,T3_CH_Volunteer,T3_US_HEPCloud,T3_US_NERSC,T3_US_OSG,T3_US_PSC,T3_US_SDSC,T3_US_MIT"
+
+queue 1
+
+EOF2
+# -----------------------------------------------------------------------------
+echo "Made config: $CONFIG"
+
+sleep 0.5
+condor_submit $CONFIG
+wait

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/MakeCondorSkim.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/MakeCondorSkim.sh
@@ -52,9 +52,7 @@ which root
 which hadd
 echo ""
 echo ">>> Setting up directory"
-while ! [ -d "MITHIGAnalysis2024" ]; do
-  xrdcp -r -f --notlsok root://xrootd.cmsaf.mit.edu//store/user/$USER/MITHIGAnalysis2024 .
-done
+xrdcp -r -f --notlsok root://xrootd.cmsaf.mit.edu//store/user/$USER/MITHIGAnalysis2024 .
 cd MITHIGAnalysis2024
 source SetupAnalysis.sh
 wait

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/MakeXrdFileList.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/MakeXrdFileList.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# xrootd server (e.g. "root://xrootd.cmsaf.mit.edu/")
+XROOTD_SERVER=$1
+# Path to dir with files on server (can have subdirs)
+SOURCE_DIR=$2
+# Filename for output list
+FILE_LIST=$3
+
+# Make list of all files in parent dir
+rm $FILE_LIST
+wait
+xrdfs $XROOTD_SERVER ls -R $SOURCE_DIR >> $FILE_LIST
+wait
+if [ -z "$FILE_LIST" ]; then
+  echo "No files found in remote directory: $SOURCE_DIR"
+  exit 1
+else
+  echo "Building file list for remote directory: $SOURCE_DIR"
+fi
+# Temp file for valid paths
+TEMP_LIST=$(mktemp)
+FILE_COUNTER=0
+# Keep only paths ending with '.root'
+while read -r LINE; do
+  if [[ "$LINE" =~ \.root$ ]]; then
+    echo "$XROOTD_SERVER/$LINE" >> "$TEMP_LIST"
+    wait
+    FILE_COUNTER=$((FILE_COUNTER + 1))
+    if ! (( $FILE_COUNTER % 100 )); then
+      echo "Found $FILE_COUNTER files..."
+    fi
+  else
+    continue
+  fi
+done < $FILE_LIST
+# Replace the original file with the temp file
+rm $FILE_LIST
+mv "$TEMP_LIST" "$FILE_LIST"
+wait
+
+echo "Found $FILE_COUNTER root files in $SOURCE_DIR"

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/README.md
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/README.md
@@ -1,0 +1,189 @@
+# Requirements
+
+* CMSSW_13_2_4
+* ROOT v6.30
+* g++ 11
+* Enterprise Linux 9 (el9) with x86_64 architecture
+
+
+# Setup
+
+You will need an account for 
+[MIT SubMIT](https://submit.mit.edu/submit-users-guide/index.html) and a 
+[CERN/CMS certificate](https://uscms.org/uscms_at_work/computing/getstarted/get_grid_cert.shtml). 
+If you need a SubMIT account you can [request one here](https://submit.mit.edu) 
+through the SubMIT Portal. You can only use an ssh key to autheticate!
+Passwords do not work.
+
+Connect to Submit:
+```bash
+ssh <user>@submit.mit.edu
+```
+
+Navigate to your working directory and install CMSSW:
+```bash
+source /cvmfs/cms.cern.ch/cmsset_default.sh
+cmsrel CMSSW_13_2_4
+cd CMSSW_13_2_4/src/
+cmsenv
+cd -
+```
+
+Clone the MITHIGAnalysis2024 repository:
+```bash
+git clone --recursive git@github.com:ginnocen/MITHIGAnalysis2024.git
+cd MITHIGAnalysis2024/
+source SetupAnalysis.sh
+cd SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/
+source clean.sh
+```
+
+You should be ready. If you make changes to `ReduceForest.cpp`, `makefile`, or 
+change anything under the `include/` folder or `MITHIGAnalysis2024/CommonCode/`,
+then you will need to update the slimmed repo files on `T2_US_MIT`. Edit the 
+paths in `CopyToT2.sh` and run with:
+```bash
+bash CopyToT2.sh
+```
+
+# Skimming with Condor
+
+## Running
+
+**Easy Process**
+
+Set the following variables at the top of `RunCondorSkim.sh`:
+```bash
+# Includes VOMS proxy in process
+REFRESH_PROXY=1
+# Copies key scripts from MITHIGAnalysis to T2_US_MIT for compiler
+COPY_TO_T2=1
+```
+This will prompt you to initiate your VOMS certificate and copy changes. If you
+are starting multiple sets of jobs in a short time or without changing other 
+files, you can set these to `0`.
+
+**Manual Process**
+
+Refresh your VOMS proxy and run `RunCondorSkim.sh`:
+```bash
+voms-proxy-init -rfc -voms cms -valid 72:00
+cp /tmp/x509up_u'$(id -u)' ~/
+
+bash RunCondorSkim.sh
+```
+
+Check the status of condor jobs with:
+```bash
+condor_q
+```
+
+Kill or remove bad jobs with:
+```bash
+condor_rm <job_id>
+```
+
+Once jobs are complete (whether successful or failed), they will no longer
+appear on the `condor_q` list.
+
+Log files are saved to `condorConfigs_<YYYYMMDD>/`:
+```bash
+# log of job and server status
+jobX_log_<job_id>.txt
+# log of errors printed by the job scripts (some outputs will print here too)
+jobX_err_<job_id>.txt
+# log of print statements from job scripts
+jobX_out_<job_id>.txt
+```
+
+
+## Making Changes
+
+Edit `RunSkimCondor.sh` to select the runs and PD range to skim over. You can 
+also edit `MakeXrdFileList.sh` and `MakeCondorSkim.sh` to change the Condor 
+configuration and job script template without having to copy changed files 
+over to T2.
+
+
+
+## Important Files
+
+**RunCondorSkim.sh**
+
+Loops over the configured list of runs and PDs and submits one job for each
+run + PD combination. You can also edit this to change the source and output 
+locations on `T2_US_MIT`.
+
+**MakeXrdFileList.sh**
+
+Makes a master list of file paths from any xrootd enable server (such as 
+`T2_US_MIT`) that will be filtered and processed in jobs.
+
+**MakeCondorSkim.sh**
+
+Creates the Condor submission file and the bash script that is executed on
+the Condor servers. The job script starts after `cat > $SCRIPT <<EOF1` and ends
+at the line `EOF1`. The Condor config starts after `cat > $CONFIG <<EOF2` and
+ends at `EOF2`.
+
+**CopyToT2.sh**
+
+Copies essential files from the local `MITHIGAnalysis2024` repo to `T2_US_MIT`
+so they can be copied to every server at the start of a new job. This should
+only be needed if `ReduceForest.cpp`, `makefile`, `include/` or 
+`MITHIGAnalysis2024/CommonCode/` are changed.
+
+# Useful Commands
+
+## Condor
+
+```bash
+condor_submit <condor_config_file>
+condor_q
+condor_rm <job_id>
+```
+
+
+## xrootd
+
+**CERN eos:** `root://eoscms.cern.ch/` `/store/group/phys_heavyions/<user>/`
+**MIT T2:** `root://xrootd.cmsaf.mit.edu/` `/store/user/<user>/`
+
+```bash
+# Recursive list
+xrdfs <server> ls -R -l <path>
+# Make directory
+xrdfs <server> mkdir -p <path/new_dir>
+
+# Copy
+xrdcp <server//path/new_dir> <local/path>
+# Recursive copy for directory
+xrdcp -r <server//path/dir> <local/path>
+# Forced copy (overwrite)
+xrdcp -f <server//path/file> <local/path>
+
+# Delete file
+xrdfs <server> rm <path/file.ext>
+# Delete directory
+xrdfs <server> rmdir <path/dir>
+```
+
+
+## VOMS
+
+```bash
+voms-proxy-init --rfc --voms cms -valid 72:00
+voms-proxy-info
+```
+
+To make it easier to initiate proxies, add this to `~/.bashrc`:
+```bash
+alias proxy='voms-proxy-init -rfc -voms cms -valid 72:00 ; cp /tmp/x509up_u'$(id -u)' ~/ ;'
+export PROXYFILE=~/x509up_u$(id -u)
+```
+Reset your terminal:
+```bash
+hash -r
+source ~/.bashrc
+```
+From now on, you can initiate a new proxy with the command `proxy`!

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunCondorSkim.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunCondorSkim.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+DATE=$(date +%Y%m%d)
+XROOTD_SERVER="root://xrootd.cmsaf.mit.edu/"
+SOURCE_DIR="/store/user/jdlang/run3_2023Data_Jan2024ReReco"
+OUTPUT_DIR="/store/user/jdlang/run3_2023Data_Jan2024ReReco_Skims_20250108"
+CONFIG_DIR="condorSkimConfigs_${DATE}"
+MASTER_FILE_LIST="${CONFIG_DIR}/forestFilesForSkim.txt"
+FILES_PER_JOB=200
+
+# Includes VOMS proxy in process
+REFRESH_PROXY=0
+# Copies key scripts from MITHIGAnalysis to T2_US_MIT for compiler
+COPY_TO_T2=0
+
+if [[ $REFRESH_PROXY -eq 1 ]]; then
+  voms-proxy-init -rfc -voms cms -valid 120:00
+  cp /tmp/x509up_u'$(id -u)' ~/
+  export PROXYFILE=~/x509up_u$(id -u)
+fi
+if [[ $COPY_TO_T2 -eq 1 ]]; then
+  ./CopyToT2.sh
+  wait
+fi
+xrdfs $XROOTD_SERVER mkdir -p $OUTPUT_DIR
+mkdir -p $CONFIG_DIR
+./MakeXrdFileList.sh $XROOTD_SERVER $SOURCE_DIR $MASTER_FILE_LIST
+
+# Function for job submission
+submit_condor_jobs() {
+  local BASENAME=$1
+  local JOB_LIST=$2
+  local JOB_COUNTER=$3
+  OUTPUT_PATH="${OUTPUT_DIR}/skim_output_${JOB_COUNTER}.root"
+  ./MakeCondorSkim.sh $BASENAME $JOB_LIST $CONFIG_DIR $XROOTD_SERVER $OUTPUT_PATH $PROXYFILE
+  wait
+  sleep 0.5
+  return 0
+}
+
+# Split list into jobs
+FILE_COUNTER=0
+JOB_COUNTER=1
+BASENAME="job${JOB_COUNTER}"
+JOB_LIST="${CONFIG_DIR}/${BASENAME}_filelist.txt"
+rm $JOB_LIST
+while IFS= read -r LINE; do
+  echo "$LINE" >> "$JOB_LIST"
+  FILE_COUNTER=$((FILE_COUNTER + 1))
+  if (( $FILE_COUNTER % $FILES_PER_JOB == 0 )); then
+    if [[ JOB_COUNTER -eq 3 ]]; then
+      break
+    fi
+    submit_condor_jobs $BASENAME $JOB_LIST $JOB_COUNTER
+    JOB_COUNTER=$((JOB_COUNTER + 1))
+    BASENAME="job${JOB_COUNTER}"
+    JOB_LIST="${CONFIG_DIR}/${BASENAME}_filelist.txt"
+  fi
+done < $MASTER_FILE_LIST
+# Submit final job list
+submit_condor_jobs $BASENAME $JOB_LIST $JOB_COUNTER


### PR DESCRIPTION
Added 4 new scripts and a README for processing skims with Condor:

- **RunCondorSkim.sh** is the main config file. Modify this to set the source for forest files.
- **MakeXrdFileList.sh** is for creating lists of root files using xrootd. This is meant for T2_US_MIT, but should work for any server with xrootd.
- **MakeCondorSkim.sh** creates the condor config and the script executed for each job.
- **CopyToT2.sh** copies key directories from MITHIGAnalysis2024 to a directory on T2 so they can be accessed for compiling ReduceForest.cpp at each job site (private github repo prevents cloning directly)