### PR TITLE
Improves flexibility of condor skimmer

### DIFF
--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/MakeCondorSkim.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/MakeCondorSkim.sh
@@ -4,9 +4,11 @@
 BASENAME=$1
 JOB_LIST=$2
 CONFIG_DIR=$3
-XROOTD_SERVER=$4
+OUTPUT_SERVER=$4
 OUTPUT_PATH=$5
 PROXYFILE=$6
+JOB_MEMORY=$7
+JOB_STORAGE=$8
 
 ANALYSIS_SUBDIR='SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/'
 SCRIPT="${CONFIG_DIR}/${BASENAME}_script.sh"
@@ -103,6 +105,7 @@ while read -r ROOT_IN_T2; do
     --IsData true \\
     --PFTree particleFlowAnalyser/pftree &
   wait
+  sleep 1
   rm \$ROOT_IN_LOCAL
   ((COUNTER++))
 done < $JOB_LIST_NAME
@@ -117,7 +120,7 @@ hadd -ff ${BASENAME}_merged.root output/${BASENAME}_*.root
 wait
 echo ""
 echo ">>> Transferring merged root file to T2"
-xrdcp -f --notlsok ${BASENAME}_merged.root ${XROOTD_SERVER}${OUTPUT_PATH}
+xrdcp -f --notlsok ${BASENAME}_merged.root ${OUTPUT_SERVER}${OUTPUT_PATH}
 wait
 echo ""
 echo ">>> Done!"
@@ -134,8 +137,8 @@ sleep 0.5
 cat > $CONFIG <<EOF2
 ### Job settings
 Universe                = vanilla
-request_disk            = 6GB
-request_memory          = 3GB
+request_disk            = ${JOB_STORAGE}GB
+request_memory          = ${JOB_MEMORY}GB
 initialdir              = $PWD/
 executable              = $PWD/$SCRIPT
 arguments               = \$(ClusterId) \$(ProcId)

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunCondorSkim.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunCondorSkim.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
 
-DATE=$(date +%Y%m%d)
-XROOTD_SERVER="root://xrootd.cmsaf.mit.edu/"
+SOURCE_SERVER="root://xrootd.cmsaf.mit.edu/"
 SOURCE_DIR="/store/user/jdlang/run3_2023Data_Jan2024ReReco"
+OUTPUT_SERVER="root://xrootd.cmsaf.mit.edu/"
 OUTPUT_DIR="/store/user/jdlang/run3_2023Data_Jan2024ReReco_Skims_20250108"
+
+DATE=$(date +%Y%m%d)
 CONFIG_DIR="condorSkimConfigs_${DATE}"
 MASTER_FILE_LIST="${CONFIG_DIR}/forestFilesForSkim.txt"
 FILES_PER_JOB=200
+# Resource request in GB:
+JOB_MEMORY=5
+JOB_STORAGE=10
 
 # Includes VOMS proxy in process
-REFRESH_PROXY=0
+REFRESH_PROXY=1
 # Copies key scripts from MITHIGAnalysis to T2_US_MIT for compiler
-COPY_TO_T2=0
+COPY_TO_T2=1
 
 if [[ $REFRESH_PROXY -eq 1 ]]; then
   voms-proxy-init -rfc -voms cms -valid 120:00
@@ -22,9 +27,9 @@ if [[ $COPY_TO_T2 -eq 1 ]]; then
   ./CopyToT2.sh
   wait
 fi
-xrdfs $XROOTD_SERVER mkdir -p $OUTPUT_DIR
+xrdfs $OUTPUT_SERVER mkdir -p $OUTPUT_DIR
 mkdir -p $CONFIG_DIR
-./MakeXrdFileList.sh $XROOTD_SERVER $SOURCE_DIR $MASTER_FILE_LIST
+./MakeXrdFileList.sh $SOURCE_SERVER $SOURCE_DIR $MASTER_FILE_LIST
 
 # Function for job submission
 submit_condor_jobs() {
@@ -32,7 +37,7 @@ submit_condor_jobs() {
   local JOB_LIST=$2
   local JOB_COUNTER=$3
   OUTPUT_PATH="${OUTPUT_DIR}/skim_output_${JOB_COUNTER}.root"
-  ./MakeCondorSkim.sh $BASENAME $JOB_LIST $CONFIG_DIR $XROOTD_SERVER $OUTPUT_PATH $PROXYFILE
+  ./MakeCondorSkim.sh $BASENAME $JOB_LIST $CONFIG_DIR $OUTPUT_SERVER $OUTPUT_PATH $PROXYFILE $JOB_MEMORY $JOB_STORAGE
   wait
   sleep 0.5
   return 0

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunCondorSkim.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunCondorSkim.sh
@@ -11,12 +11,12 @@ MASTER_FILE_LIST="${CONFIG_DIR}/forestFilesForSkim.txt"
 FILES_PER_JOB=200
 # Resource request in GB:
 JOB_MEMORY=5
-JOB_STORAGE=10
+JOB_STORAGE=20
 
 # Includes VOMS proxy in process
-REFRESH_PROXY=1
+REFRESH_PROXY=0
 # Copies key scripts from MITHIGAnalysis to T2_US_MIT for compiler
-COPY_TO_T2=1
+COPY_TO_T2=0
 
 if [[ $REFRESH_PROXY -eq 1 ]]; then
   voms-proxy-init -rfc -voms cms -valid 120:00
@@ -53,9 +53,6 @@ while IFS= read -r LINE; do
   echo "$LINE" >> "$JOB_LIST"
   FILE_COUNTER=$((FILE_COUNTER + 1))
   if (( $FILE_COUNTER % $FILES_PER_JOB == 0 )); then
-    if [[ JOB_COUNTER -eq 3 ]]; then
-      break
-    fi
     submit_condor_jobs $BASENAME $JOB_LIST $JOB_COUNTER
     JOB_COUNTER=$((JOB_COUNTER + 1))
     BASENAME="job${JOB_COUNTER}"


### PR DESCRIPTION
Splits `XROOTD_SERVER` into separate options for the source and output. This should allow for using forests stored outside of T2_US_MIT or saving skims to other sites.

Added variables to set the requested job memory and storage from `RunCondorSkim.sh` to make this configuration easier.

Removed an if-statement used to test.