### PR TITLE
[new] systematics branches in the skim; fit modeling systematics; a small improvement on the fit config

### DIFF
--- a/CommonCode/include/Messenger.h
+++ b/CommonCode/include/Messenger.h
@@ -788,7 +788,7 @@ public:
    std::vector<float> *Ddtheta;
    std::vector<bool> *DpassCut23PAS;
    std::vector<bool> *DpassCut23LowPt;
-   std::vector<bool> *DpassCut23PASSystDsvpv;
+   std::vector<bool> *DpassCut23PASSystDsvpvSig;
    std::vector<bool> *DpassCut23PASSystDtrkPt;
    std::vector<int> *Dgen;
    std::vector<bool> *DisSignalCalc;
@@ -802,6 +802,10 @@ public:
    std::vector<bool> *GisSignalCalcPrompt;
    std::vector<bool> *GisSignalCalcFeeddown;
 
+   ///////////////////
+   // Defining the rapidity gap energy threshold array for the systematics study -- 1
+   // [Change accordingly] function gammaN_EThresh*()
+   ///////////////////
    const int N_gapEThresh = 9;
    // from tight to loose
    const std::vector<float> gapEThresh_gammaN = {4.3, 5.5, 6.4, 7.8, 9.2, 10.6, 12.5, 15.0, 16.2};
@@ -828,6 +832,10 @@ public:
    void CopyNonTrack(DzeroUPCTreeMessenger &M);
    bool FillEntry();
 
+   ///////////////////
+   // Utility functions to examine passing a specific rapidity gap energy threshold -- 2
+   // [Change accordingly] the declaration of gapEThresh_*
+   ///////////////////
    bool gammaN_EThreshTight()   { if (this->gammaN->size()!=N_gapEThresh) return false; return this->gammaN->at(0); }
    bool gammaN_EThreshLoose()   { if (this->gammaN->size()!=N_gapEThresh) return false; return this->gammaN->at(N_gapEThresh-1); }
    bool gammaN_EThreshNominal() { if (this->gammaN->size()!=N_gapEThresh) return false; return this->gammaN->at(N_gapEThresh/2); }

--- a/CommonCode/include/Messenger.h
+++ b/CommonCode/include/Messenger.h
@@ -788,6 +788,8 @@ public:
    std::vector<float> *Ddtheta;
    std::vector<bool> *DpassCut23PAS;
    std::vector<bool> *DpassCut23LowPt;
+   std::vector<bool> *DpassCut23PASSystDsvpv;
+   std::vector<bool> *DpassCut23PASSystDtrkPt;
    std::vector<int> *Dgen;
    std::vector<bool> *DisSignalCalc;
    std::vector<bool> *DisSignalCalcPrompt;
@@ -799,6 +801,11 @@ public:
    std::vector<bool> *GisSignalCalc;
    std::vector<bool> *GisSignalCalcPrompt;
    std::vector<bool> *GisSignalCalcFeeddown;
+
+   const int N_gapEThresh = 9;
+   // from tight to loose
+   const std::vector<float> gapEThresh_gammaN = {4.3, 5.5, 6.4, 7.8, 9.2, 10.6, 12.5, 15.0, 16.2};
+   const std::vector<float> gapEThresh_Ngamma = {4.5, 5.5, 6.5, 7.6, 8.6, 10.0, 12.0, 15.0, 16.0};
 
 public:   // Derived quantities
    bool GoodPhotonuclear; //FIXME: currently not implemented
@@ -820,6 +827,18 @@ public:
    void Clear();
    void CopyNonTrack(DzeroUPCTreeMessenger &M);
    bool FillEntry();
+
+   bool gammaN_EThreshTight()   { if (this->gammaN->size()!=N_gapEThresh) return false; return this->gammaN->at(0); }
+   bool gammaN_EThreshLoose()   { if (this->gammaN->size()!=N_gapEThresh) return false; return this->gammaN->at(N_gapEThresh-1); }
+   bool gammaN_EThreshNominal() { if (this->gammaN->size()!=N_gapEThresh) return false; return this->gammaN->at(N_gapEThresh/2); }
+   bool gammaN_EThreshSyst5p5() { if (this->gammaN->size()!=N_gapEThresh) return false; return this->gammaN->at(1); }
+   bool gammaN_EThreshSyst15()  { if (this->gammaN->size()!=N_gapEThresh) return false; return this->gammaN->at(7); }
+   bool Ngamma_EThreshTight()   { if (this->Ngamma->size()!=N_gapEThresh) return false; return this->Ngamma->at(0); }
+   bool Ngamma_EThreshLoose()   { if (this->Ngamma->size()!=N_gapEThresh) return false; return this->Ngamma->at(N_gapEThresh-1); }
+   bool Ngamma_EThreshNominal() { if (this->Ngamma->size()!=N_gapEThresh) return false; return this->Ngamma->at(N_gapEThresh/2); }
+   bool Ngamma_EThreshSyst5p5() { if (this->Ngamma->size()!=N_gapEThresh) return false; return this->Ngamma->at(1); }
+   bool Ngamma_EThreshSyst15()  { if (this->Ngamma->size()!=N_gapEThresh) return false; return this->Ngamma->at(7); }
+
 };
 
 class MuMuJetMessenger

--- a/CommonCode/source/Messenger.cpp
+++ b/CommonCode/source/Messenger.cpp
@@ -2815,7 +2815,7 @@ DzeroUPCTreeMessenger::~DzeroUPCTreeMessenger()
       delete Dpt;
       delete DpassCut23PAS;
       delete DpassCut23LowPt;
-      delete DpassCut23PASSystDsvpv;
+      delete DpassCut23PASSystDsvpvSig;
       delete DpassCut23PASSystDtrkPt;
       delete Dy;
       delete Dmass;
@@ -2857,7 +2857,7 @@ bool DzeroUPCTreeMessenger::Initialize(bool Debug)
    Dpt = nullptr;
    DpassCut23PAS = nullptr;
    DpassCut23LowPt = nullptr;
-   DpassCut23PASSystDsvpv = nullptr;
+   DpassCut23PASSystDsvpvSig = nullptr;
    DpassCut23PASSystDtrkPt = nullptr;
    Dy = nullptr;
    Dmass = nullptr;
@@ -2922,7 +2922,7 @@ bool DzeroUPCTreeMessenger::Initialize(bool Debug)
    Tree->SetBranchAddress("Ddtheta", &Ddtheta);
    Tree->SetBranchAddress("DpassCut23PAS", &DpassCut23PAS);
    Tree->SetBranchAddress("DpassCut23LowPt", &DpassCut23LowPt);
-   Tree->SetBranchAddress("DpassCut23PASSystDsvpv", &DpassCut23PASSystDsvpv);
+   Tree->SetBranchAddress("DpassCut23PASSystDsvpvSig", &DpassCut23PASSystDsvpvSig);
    Tree->SetBranchAddress("DpassCut23PASSystDtrkPt", &DpassCut23PASSystDtrkPt);
    Tree->SetBranchAddress("Dgen", &Dgen);
    Tree->SetBranchAddress("DisSignalCalc", &DisSignalCalc);
@@ -2966,7 +2966,7 @@ bool DzeroUPCTreeMessenger::SetBranch(TTree *T)
    Dpt = new std::vector<float>();
    DpassCut23PAS = new std::vector<bool>();
    DpassCut23LowPt = new std::vector<bool>();
-   DpassCut23PASSystDsvpv = new std::vector<bool>();
+   DpassCut23PASSystDsvpvSig = new std::vector<bool>();
    DpassCut23PASSystDtrkPt = new std::vector<bool>();
    Dy = new std::vector<float>();
    Dmass = new std::vector<float>();
@@ -3035,7 +3035,7 @@ bool DzeroUPCTreeMessenger::SetBranch(TTree *T)
    Tree->Branch("Ddtheta",               &Ddtheta);
    Tree->Branch("DpassCut23PAS",         &DpassCut23PAS);
    Tree->Branch("DpassCut23LowPt",       &DpassCut23LowPt);
-   Tree->Branch("DpassCut23PASSystDsvpv",&DpassCut23PASSystDsvpv);
+   Tree->Branch("DpassCut23PASSystDsvpvSig",&DpassCut23PASSystDsvpvSig);
    Tree->Branch("DpassCut23PASSystDtrkPt",&DpassCut23PASSystDtrkPt);
    Tree->Branch("Dgen",                  &Dgen);
    Tree->Branch("DisSignalCalc",         &DisSignalCalc);
@@ -3098,7 +3098,7 @@ void DzeroUPCTreeMessenger::Clear()
    Ddtheta->clear();
    DpassCut23PAS->clear();
    DpassCut23LowPt->clear();
-   DpassCut23PASSystDsvpv->clear();
+   DpassCut23PASSystDsvpvSig->clear();
    DpassCut23PASSystDtrkPt->clear();
    Dgen->clear();
    DisSignalCalc->clear();
@@ -3156,7 +3156,7 @@ void DzeroUPCTreeMessenger::CopyNonTrack(DzeroUPCTreeMessenger &M)
    if(Ddtheta != nullptr && M.Ddtheta != nullptr)   *Ddtheta = *(M.Ddtheta);
    if(DpassCut23PAS != nullptr && M.DpassCut23PAS != nullptr)   *DpassCut23PAS = *(M.DpassCut23PAS);
    if(DpassCut23LowPt != nullptr && M.DpassCut23LowPt != nullptr)   *DpassCut23LowPt = *(M.DpassCut23LowPt);
-   if(DpassCut23PASSystDsvpv != nullptr && M.DpassCut23PASSystDsvpv != nullptr)   *DpassCut23PASSystDsvpv = *(M.DpassCut23PASSystDsvpv);
+   if(DpassCut23PASSystDsvpvSig != nullptr && M.DpassCut23PASSystDsvpvSig != nullptr)   *DpassCut23PASSystDsvpvSig = *(M.DpassCut23PASSystDsvpvSig);
    if(DpassCut23PASSystDtrkPt != nullptr && M.DpassCut23PASSystDtrkPt != nullptr)   *DpassCut23PASSystDtrkPt = *(M.DpassCut23PASSystDtrkPt);
    if(Dgen != nullptr && M.Dgen != nullptr)   *Dgen = *(M.Dgen);
    if(DisSignalCalc != nullptr && M.DisSignalCalc != nullptr)   *DisSignalCalc = *(M.DisSignalCalc);

--- a/CommonCode/source/Messenger.cpp
+++ b/CommonCode/source/Messenger.cpp
@@ -2815,6 +2815,8 @@ DzeroUPCTreeMessenger::~DzeroUPCTreeMessenger()
       delete Dpt;
       delete DpassCut23PAS;
       delete DpassCut23LowPt;
+      delete DpassCut23PASSystDsvpv;
+      delete DpassCut23PASSystDtrkPt;
       delete Dy;
       delete Dmass;
       delete Dtrk1Pt;
@@ -2855,6 +2857,8 @@ bool DzeroUPCTreeMessenger::Initialize(bool Debug)
    Dpt = nullptr;
    DpassCut23PAS = nullptr;
    DpassCut23LowPt = nullptr;
+   DpassCut23PASSystDsvpv = nullptr;
+   DpassCut23PASSystDtrkPt = nullptr;
    Dy = nullptr;
    Dmass = nullptr;
    Dtrk1Pt = nullptr;
@@ -2918,6 +2922,8 @@ bool DzeroUPCTreeMessenger::Initialize(bool Debug)
    Tree->SetBranchAddress("Ddtheta", &Ddtheta);
    Tree->SetBranchAddress("DpassCut23PAS", &DpassCut23PAS);
    Tree->SetBranchAddress("DpassCut23LowPt", &DpassCut23LowPt);
+   Tree->SetBranchAddress("DpassCut23PASSystDsvpv", &DpassCut23PASSystDsvpv);
+   Tree->SetBranchAddress("DpassCut23PASSystDtrkPt", &DpassCut23PASSystDtrkPt);
    Tree->SetBranchAddress("Dgen", &Dgen);
    Tree->SetBranchAddress("DisSignalCalc", &DisSignalCalc);
    Tree->SetBranchAddress("DisSignalCalcPrompt", &DisSignalCalcPrompt);
@@ -2960,6 +2966,8 @@ bool DzeroUPCTreeMessenger::SetBranch(TTree *T)
    Dpt = new std::vector<float>();
    DpassCut23PAS = new std::vector<bool>();
    DpassCut23LowPt = new std::vector<bool>();
+   DpassCut23PASSystDsvpv = new std::vector<bool>();
+   DpassCut23PASSystDtrkPt = new std::vector<bool>();
    Dy = new std::vector<float>();
    Dmass = new std::vector<float>();
    Dtrk1Pt = new std::vector<float>();
@@ -3027,6 +3035,8 @@ bool DzeroUPCTreeMessenger::SetBranch(TTree *T)
    Tree->Branch("Ddtheta",               &Ddtheta);
    Tree->Branch("DpassCut23PAS",         &DpassCut23PAS);
    Tree->Branch("DpassCut23LowPt",       &DpassCut23LowPt);
+   Tree->Branch("DpassCut23PASSystDsvpv",&DpassCut23PASSystDsvpv);
+   Tree->Branch("DpassCut23PASSystDtrkPt",&DpassCut23PASSystDtrkPt);
    Tree->Branch("Dgen",                  &Dgen);
    Tree->Branch("DisSignalCalc",         &DisSignalCalc);
    Tree->Branch("DisSignalCalcPrompt",   &DisSignalCalcPrompt);
@@ -3088,6 +3098,8 @@ void DzeroUPCTreeMessenger::Clear()
    Ddtheta->clear();
    DpassCut23PAS->clear();
    DpassCut23LowPt->clear();
+   DpassCut23PASSystDsvpv->clear();
+   DpassCut23PASSystDtrkPt->clear();
    Dgen->clear();
    DisSignalCalc->clear();
    DisSignalCalcPrompt->clear();
@@ -3144,6 +3156,8 @@ void DzeroUPCTreeMessenger::CopyNonTrack(DzeroUPCTreeMessenger &M)
    if(Ddtheta != nullptr && M.Ddtheta != nullptr)   *Ddtheta = *(M.Ddtheta);
    if(DpassCut23PAS != nullptr && M.DpassCut23PAS != nullptr)   *DpassCut23PAS = *(M.DpassCut23PAS);
    if(DpassCut23LowPt != nullptr && M.DpassCut23LowPt != nullptr)   *DpassCut23LowPt = *(M.DpassCut23LowPt);
+   if(DpassCut23PASSystDsvpv != nullptr && M.DpassCut23PASSystDsvpv != nullptr)   *DpassCut23PASSystDsvpv = *(M.DpassCut23PASSystDsvpv);
+   if(DpassCut23PASSystDtrkPt != nullptr && M.DpassCut23PASSystDtrkPt != nullptr)   *DpassCut23PASSystDtrkPt = *(M.DpassCut23PASSystDtrkPt);
    if(Dgen != nullptr && M.Dgen != nullptr)   *Dgen = *(M.Dgen);
    if(DisSignalCalc != nullptr && M.DisSignalCalc != nullptr)   *DisSignalCalc = *(M.DisSignalCalc);
    if(DisSignalCalcPrompt != nullptr && M.DisSignalCalcPrompt != nullptr)   *DisSignalCalcPrompt = *(M.DisSignalCalcPrompt);

--- a/MainAnalysis/20241210_DzeroUPC/README.md
+++ b/MainAnalysis/20241210_DzeroUPC/README.md
@@ -20,11 +20,12 @@
 		```
 		<MicroTreeDir>/
 		 ├── sampleConfig.json: the config card in the `sampleSettings` folder, which controls the execution of `DzeroUPC.cpp` 
+		 ├── FitDir{1...}.json: the fitting config cards for all the pt,y bins 
 		 ├── <pt_xxx_y_xxx>/
 		 │	├── Data.root
 		 │	├── MC.root
   		 │	├── <FitDir1>/
-		 │	│ 	├── fitConfig.json:  the config card in the `fitSettings` folder, which controls the execution of `massfit.C`
+		 │	│ 	├── fitConfig.json:  a part of the config card in the `fitSettings` folder that limits to this specific pt,y bin, which controls the execution of `massfit.C`
 		 │	│ 	├── from massfit.C:  sigl.dat, swap.dat, pkkk.dat (peaking KK), pkpp.dat (peaking pipi) shape parameters from MC pre-fit
 		 │	│ 	├── from massfit.C:  events.dat normalization / fraction from MC-truth counting
 		 │	│ 	└── from massfit.C:  pdf and log

--- a/MainAnalysis/20241210_DzeroUPC/fitSettings/systFitComb.json
+++ b/MainAnalysis/20241210_DzeroUPC/fitSettings/systFitComb.json
@@ -1,0 +1,173 @@
+{
+  "FitDir": "MassFit_systComb",
+  "MicroTrees": [
+    {
+      "dataInput": "fullAnalysis/pt1-2_y-1-1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt1-2_y-1-1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt1-2_y-1-1_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y-1-1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y-1-1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y-1-1_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y-2--1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y1-2_IsGammaN1/MC_inclusive.root,fullAnalysis/pt2-5_y-2--1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y-2--1_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y-1-0_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y0-1_IsGammaN1/MC_inclusive.root,fullAnalysis/pt2-5_y-1-0_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y-1-0_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y0-1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y0-1_IsGammaN1/MC_inclusive.root,fullAnalysis/pt2-5_y-1-0_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y0-1_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y1-2_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y1-2_IsGammaN1/MC_inclusive.root,fullAnalysis/pt2-5_y-2--1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y1-2_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y-2--1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y1-2_IsGammaN1/MC_inclusive.root,fullAnalysis/pt5-8_y-2--1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y-2--1_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y-1-0_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y0-1_IsGammaN1/MC_inclusive.root,fullAnalysis/pt5-8_y-1-0_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y-1-0_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y0-1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y0-1_IsGammaN1/MC_inclusive.root,fullAnalysis/pt5-8_y-1-0_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y0-1_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y1-2_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y1-2_IsGammaN1/MC_inclusive.root,fullAnalysis/pt5-8_y-2--1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y1-2_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y-2--1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y1-2_IsGammaN1/MC_inclusive.root,fullAnalysis/pt8-12_y-2--1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y-2--1_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y-1-0_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y0-1_IsGammaN1/MC_inclusive.root,fullAnalysis/pt8-12_y-1-0_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y-1-0_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y0-1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y0-1_IsGammaN1/MC_inclusive.root,fullAnalysis/pt8-12_y-1-0_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y0-1_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y1-2_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y1-2_IsGammaN1/MC_inclusive.root,fullAnalysis/pt8-12_y-2--1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y1-2_IsGammaN1/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt1-2_y-1-1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt1-2_y-1-1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt1-2_y-1-1_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y-1-1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y-1-1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y-1-1_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y-2--1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y1-2_IsGammaN0/MC_inclusive.root,fullAnalysis/pt2-5_y-2--1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y-2--1_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y-1-0_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y0-1_IsGammaN0/MC_inclusive.root,fullAnalysis/pt2-5_y-1-0_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y-1-0_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y0-1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y0-1_IsGammaN0/MC_inclusive.root,fullAnalysis/pt2-5_y-1-0_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y0-1_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y1-2_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y1-2_IsGammaN0/MC_inclusive.root,fullAnalysis/pt2-5_y-2--1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y1-2_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y-2--1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y1-2_IsGammaN0/MC_inclusive.root,fullAnalysis/pt5-8_y-2--1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y-2--1_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y-1-0_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y0-1_IsGammaN0/MC_inclusive.root,fullAnalysis/pt5-8_y-1-0_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y-1-0_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y0-1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y0-1_IsGammaN0/MC_inclusive.root,fullAnalysis/pt5-8_y-1-0_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y0-1_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y1-2_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y1-2_IsGammaN0/MC_inclusive.root,fullAnalysis/pt5-8_y-2--1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y1-2_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y-2--1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y1-2_IsGammaN0/MC_inclusive.root,fullAnalysis/pt8-12_y-2--1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y-2--1_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y-1-0_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y0-1_IsGammaN0/MC_inclusive.root,fullAnalysis/pt8-12_y-1-0_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y-1-0_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y0-1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y0-1_IsGammaN0/MC_inclusive.root,fullAnalysis/pt8-12_y-1-0_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y0-1_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y1-2_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y1-2_IsGammaN0/MC_inclusive.root,fullAnalysis/pt8-12_y-2--1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y1-2_IsGammaN0/MC.root",
+      "doSyst_comb": true
+    }
+  ]
+}

--- a/MainAnalysis/20241210_DzeroUPC/fitSettings/systFitSig.json
+++ b/MainAnalysis/20241210_DzeroUPC/fitSettings/systFitSig.json
@@ -1,0 +1,173 @@
+{
+  "FitDir": "MassFit_systSig",
+  "MicroTrees": [
+    {
+      "dataInput": "fullAnalysis/pt1-2_y-1-1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt1-2_y-1-1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt1-2_y-1-1_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y-1-1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y-1-1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y-1-1_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y-2--1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y1-2_IsGammaN1/MC_inclusive.root,fullAnalysis/pt2-5_y-2--1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y-2--1_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y-1-0_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y0-1_IsGammaN1/MC_inclusive.root,fullAnalysis/pt2-5_y-1-0_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y-1-0_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y0-1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y0-1_IsGammaN1/MC_inclusive.root,fullAnalysis/pt2-5_y-1-0_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y0-1_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y1-2_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y1-2_IsGammaN1/MC_inclusive.root,fullAnalysis/pt2-5_y-2--1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y1-2_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y-2--1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y1-2_IsGammaN1/MC_inclusive.root,fullAnalysis/pt5-8_y-2--1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y-2--1_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y-1-0_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y0-1_IsGammaN1/MC_inclusive.root,fullAnalysis/pt5-8_y-1-0_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y-1-0_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y0-1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y0-1_IsGammaN1/MC_inclusive.root,fullAnalysis/pt5-8_y-1-0_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y0-1_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y1-2_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y1-2_IsGammaN1/MC_inclusive.root,fullAnalysis/pt5-8_y-2--1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y1-2_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y-2--1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y1-2_IsGammaN1/MC_inclusive.root,fullAnalysis/pt8-12_y-2--1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y-2--1_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y-1-0_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y0-1_IsGammaN1/MC_inclusive.root,fullAnalysis/pt8-12_y-1-0_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y-1-0_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y0-1_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y0-1_IsGammaN1/MC_inclusive.root,fullAnalysis/pt8-12_y-1-0_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y0-1_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y1-2_IsGammaN1/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y1-2_IsGammaN1/MC_inclusive.root,fullAnalysis/pt8-12_y-2--1_IsGammaN1/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y1-2_IsGammaN1/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt1-2_y-1-1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt1-2_y-1-1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt1-2_y-1-1_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y-1-1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y-1-1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y-1-1_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y-2--1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y1-2_IsGammaN0/MC_inclusive.root,fullAnalysis/pt2-5_y-2--1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y-2--1_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y-1-0_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y0-1_IsGammaN0/MC_inclusive.root,fullAnalysis/pt2-5_y-1-0_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y-1-0_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y0-1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y0-1_IsGammaN0/MC_inclusive.root,fullAnalysis/pt2-5_y-1-0_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y0-1_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt2-5_y1-2_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt2-5_y1-2_IsGammaN0/MC_inclusive.root,fullAnalysis/pt2-5_y-2--1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt2-5_y1-2_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y-2--1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y1-2_IsGammaN0/MC_inclusive.root,fullAnalysis/pt5-8_y-2--1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y-2--1_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y-1-0_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y0-1_IsGammaN0/MC_inclusive.root,fullAnalysis/pt5-8_y-1-0_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y-1-0_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y0-1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y0-1_IsGammaN0/MC_inclusive.root,fullAnalysis/pt5-8_y-1-0_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y0-1_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt5-8_y1-2_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt5-8_y1-2_IsGammaN0/MC_inclusive.root,fullAnalysis/pt5-8_y-2--1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt5-8_y1-2_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y-2--1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y1-2_IsGammaN0/MC_inclusive.root,fullAnalysis/pt8-12_y-2--1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y-2--1_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y-1-0_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y0-1_IsGammaN0/MC_inclusive.root,fullAnalysis/pt8-12_y-1-0_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y-1-0_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y0-1_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y0-1_IsGammaN0/MC_inclusive.root,fullAnalysis/pt8-12_y-1-0_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y0-1_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    },
+    {
+      "dataInput": "fullAnalysis/pt8-12_y1-2_IsGammaN0/Data.root",
+      "fitmcInputs": "fullAnalysis/pt8-12_y1-2_IsGammaN0/MC_inclusive.root,fullAnalysis/pt8-12_y-2--1_IsGammaN0/MC_inclusive.root",
+      "effmcInput": "fullAnalysis/pt8-12_y1-2_IsGammaN0/MC.root",
+      "doSyst_sig": true
+    }
+  ]
+}

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/ReduceForest.cpp
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/ReduceForest.cpp
@@ -5,6 +5,8 @@
 // ===================================================
 
 #include <iostream>
+#include <set>
+#include <algorithm>
 using namespace std;
 
 #include "TFile.h"
@@ -28,6 +30,13 @@ bool logical_or_vectBool(std::vector<bool>* vec) {
     return std::any_of(vec->begin(), vec->end(), [](bool b) { return b; });
 }
 
+// Helper function to convert a string to lowercase
+std::string toLower(const std::string& str) {
+    std::string lowerStr = str;
+    std::transform(lowerStr.begin(), lowerStr.end(), lowerStr.begin(), ::tolower);
+    return lowerStr;
+}
+
 int main(int argc, char *argv[]);
 double GetMaxEnergyHF(PFTreeMessenger *M, double etaMin, double etaMax);
 
@@ -41,14 +50,25 @@ int main(int argc, char *argv[]) {
 
   // bool DoGenLevel                    = CL.GetBool("DoGenLevel", true);
   bool IsData = CL.GetBool("IsData", false);
+  bool IsGammaN = CL.GetBool("IsGammaN", true); // This is only meaningful when IsData==false. gammaN: BeamA, Ngamma: BeamB
   int Year = CL.GetInt("Year", 2023);
+
   double Fraction = CL.GetDouble("Fraction", 1.00);
   float ZDCMinus1nThreshold = CL.GetDouble("ZDCMinus1nThreshold", 1000.);
   float ZDCPlus1nThreshold = CL.GetDouble("ZDCPlus1nThreshold", 1100.);
   int ApplyTriggerRejection = CL.GetInteger("ApplyTriggerRejection", 0);
   bool ApplyEventRejection = CL.GetBool("ApplyEventRejection", false);
   bool ApplyZDCGapRejection = CL.GetBool("ApplyZDCGapRejection", false);
-  int ApplyDRejection = CL.GetInteger("ApplyDRejection", 0);
+
+  // options for how to reject non-selected D candidates (case-insensitive)
+  // "NO":            keep all D's
+  // "OR":            keep D's that pass the OR logic of all D selections
+  // "PAS":           reject !DpassCut23PAS
+  // "LowPt":         reject !DpassCut23LowPt
+  // "PASSystDsvpv":  reject !DpassCut23PASSystDsvpv
+  // "PASSystDtrkPt": reject !DpassCut23PASSystDtrkPt
+  string ApplyDRejection = toLower(CL.Get("ApplyDRejection", "no"));
+
   string PFTreeName = CL.Get("PFTree", "particleFlowAnalyser/pftree");
   string DGenTreeName = CL.Get("DGenTree", "Dfinder/ntGen");
   string ZDCTreeName = CL.Get("ZDCTree", "zdcanalyzer/zdcdigi");
@@ -57,6 +77,21 @@ int main(int argc, char *argv[]) {
   TTree InfoTree("InfoTree", "Information");
   DzeroUPCTreeMessenger MDzeroUPC;
   MDzeroUPC.SetBranch(&Tree);
+
+  // Allowed ApplyDRejection in lowercase
+  std::set<std::string> allowedApplyDRejection = {"or", "ordered_or", "pas", "lowpt", "passystdsvpv", "passystdtrkpt", "no"};
+  // Validate the argument
+  if (allowedApplyDRejection.find(ApplyDRejection) != allowedApplyDRejection.end()) {
+    std::cout << "D filtering criterion: " << ApplyDRejection << std::endl;
+    // Add your program logic here
+  } else {
+    std::cerr << "[Warning] Invalid ApplyDRejection. Set to NO rejection. Allowed ApplyDRejection are: ";
+    for (const auto& ele : allowedApplyDRejection) {
+        std::cout << ele << ", ";
+    }
+    std::cout << std::endl;
+    ApplyDRejection = "no";
+  }
 
   for (string InputFileName : InputFileNames) {
     TFile InputFile(InputFileName.c_str());
@@ -178,8 +213,8 @@ int main(int argc, char *argv[]) {
           if (ApplyTriggerRejection == 1 && IsData) std::cout << "Trigger rejection ZDCOR || ZDCXORJet8 not implemented for 2024" << std::endl;
           if (ApplyTriggerRejection == 2 && IsData && isL1ZDCOr == false) continue;
         }
-     }
-     if (IsData == true) {
+      }
+      if (IsData == true) {
         MDzeroUPC.ZDCsumPlus = MZDC.sumPlus;
         MDzeroUPC.ZDCsumMinus = MZDC.sumMinus;
         bool selectedBkgFilter = MSkim.ClusterCompatibilityFilter == 1 && MMETFilter.cscTightHalo2015Filter;
@@ -203,20 +238,54 @@ int main(int argc, char *argv[]) {
         MDzeroUPC.gapNgamma = gapNgamma;
         bool gammaN_default = ZDCgammaN && gapgammaN;
         bool Ngamma_default = ZDCNgamma && gapNgamma;
-        if (ApplyZDCGapRejection && IsData && gammaN_default == false && Ngamma_default == false) continue;
-        for (double gapgammaN_threshold = 5.2; gapgammaN_threshold <= 13.2; gapgammaN_threshold += 1.0) {
-          bool gapgammaN = GetMaxEnergyHF(&MPF, 3.0, 5.2) < gapgammaN_threshold;
-          bool gammaN_ = ZDCgammaN && gapgammaN;
+        // if (ApplyZDCGapRejection && IsData && gammaN_default == false && Ngamma_default == false) continue;
+        for (const auto& gapgammaN_threshold : MDzeroUPC.gapEThresh_gammaN) {
+          bool gapgammaN_ = GetMaxEnergyHF(&MPF, 3.0, 5.2) < gapgammaN_threshold;
+          bool gammaN_ = ZDCgammaN && gapgammaN_;
           MDzeroUPC.gammaN->push_back(gammaN_);
         }
-        for (double gapNgamma_threshold = 4.6; gapNgamma_threshold <= 12.6; gapNgamma_threshold += 1.0) {
-          bool gapNgamma = GetMaxEnergyHF(&MPF, -5.2, -3.0) < gapNgamma_threshold;
-          bool Ngamma_ = ZDCNgamma && gapNgamma;
+        for (const auto& gapNgamma_threshold : MDzeroUPC.gapEThresh_Ngamma) {
+          bool gapNgamma_ = GetMaxEnergyHF(&MPF, -5.2, -3.0) < gapNgamma_threshold;
+          bool Ngamma_ = ZDCNgamma && gapNgamma_;
           MDzeroUPC.Ngamma->push_back(Ngamma_);
         }
-        //bool evtselgammaNNgamma = logical_or_vectBool(MDzeroUPC.gammaN) || logical_or_vectBool(MDzeroUPC.Ngamma);
-        //if (ApplyEventRejection && evtselgammaNNgamma == false) continue;
+        /////// cut on the loosest rapidity gap selection
+        if (ApplyZDCGapRejection && IsData && MDzeroUPC.gammaN_EThreshLoose() == false && MDzeroUPC.Ngamma_EThreshLoose() == false) continue;
       } // end of if (IsData == true)
+      else { // if (IsData == false)
+        // MDzeroUPC.ZDCsumPlus = MZDC.sumPlus;
+        // MDzeroUPC.ZDCsumMinus = MZDC.sumMinus;
+        bool selectedBkgFilter = MSkim.ClusterCompatibilityFilter == 1; // METFilter always true for MC
+        bool selectedVtxFilter = MSkim.PVFilter == 1 && fabs(MTrackPbPbUPC.zVtx->at(0)) < 15.;
+        MDzeroUPC.selectedBkgFilter = selectedBkgFilter;
+        MDzeroUPC.selectedVtxFilter = selectedVtxFilter;
+        bool ZDCgammaN =  IsGammaN;
+        bool ZDCNgamma = !IsGammaN;
+        MDzeroUPC.ZDCgammaN = ZDCgammaN;
+        MDzeroUPC.ZDCNgamma = ZDCNgamma;
+        // Loop through the specified ranges for gapgammaN and gapNgamma
+        // gammaN[4] and Ngamma[4] are nominal selection criteria
+        float EMaxHFPlus = GetMaxEnergyHF(&MPF, 3., 5.2);
+        float EMaxHFMinus = GetMaxEnergyHF(&MPF, -5.2, -3.);
+        MDzeroUPC.HFEMaxPlus = EMaxHFPlus;
+        MDzeroUPC.HFEMaxMinus = EMaxHFMinus;
+        bool gapgammaN = EMaxHFPlus < 9.2;
+        bool gapNgamma = EMaxHFMinus < 8.6;
+        MDzeroUPC.gapgammaN = gapgammaN;
+        MDzeroUPC.gapNgamma = gapNgamma;
+        bool gammaN_default = ZDCgammaN && gapgammaN;
+        bool Ngamma_default = ZDCNgamma && gapNgamma;
+        for (const auto& gapgammaN_threshold : MDzeroUPC.gapEThresh_gammaN) {
+          bool gapgammaN_ = GetMaxEnergyHF(&MPF, 3.0, 5.2) < gapgammaN_threshold;
+          bool gammaN_ = ZDCgammaN && gapgammaN_;
+          MDzeroUPC.gammaN->push_back(gammaN_);
+        }
+        for (const auto& gapNgamma_threshold : MDzeroUPC.gapEThresh_Ngamma) {
+          bool gapNgamma_ = GetMaxEnergyHF(&MPF, -5.2, -3.0) < gapNgamma_threshold;
+          bool Ngamma_ = ZDCNgamma && gapNgamma_;
+          MDzeroUPC.Ngamma->push_back(Ngamma_);
+        }
+      } // end of if (IsData == false)
       int nTrackInAcceptanceHP = 0;
       for (int iTrack = 0; iTrack < MTrackPbPbUPC.nTrk; iTrack++) {
         if (MTrackPbPbUPC.trkPt->at(iTrack) <= 0.5)
@@ -230,8 +299,40 @@ int main(int argc, char *argv[]) {
       MDzeroUPC.nTrackInAcceptanceHP = nTrackInAcceptanceHP;
       int countSelDzero = 0;
       for (int iD = 0; iD < MDzero.Dsize; iD++) {
-        if (ApplyDRejection == 1 && IsData && DmesonSelectionPrelim23(MDzero, iD) == false) continue;
-        if (ApplyDRejection == 2 && IsData && DmesonSelectionSkimLowPt23(MDzero, iD) == false) continue;
+        bool DpassCut23PAS_           = DmesonSelectionPrelim23(MDzero, iD);
+        bool DpassCut23LowPt_         = DmesonSelectionLowPt23(MDzero, iD);
+        bool DpassCut23PASSystDsvpv_  = DmesonSelectionPrelim23SystDsvpv(MDzero, iD);
+        bool DpassCut23PASSystDtrkPt_ = DmesonSelectionPrelim23SystDtrkPt(MDzero, iD);
+        if (IsData)
+        {
+          if (ApplyDRejection=="or")
+          {
+            if (!DpassCut23PAS_ &&
+                !DpassCut23LowPt_ &&
+                !DpassCut23PASSystDsvpv_ &&
+                !DpassCut23PASSystDtrkPt_ ) continue;
+          }
+          // else if (ApplyDRejection=="ordered_or")
+          // {
+          //   if (!DmesonSelectionLowPt23(MDzero, iD))
+          //   {
+          //     if (!DmesonSelectionPrelim23SystDtrkPt(MDzero, iD))
+          //     {
+          //       if (!DmesonSelectionPrelim23SystDsvpv(MDzero, iD))
+          //       {
+          //         if (!DmesonSelectionPrelim23(MDzero, iD))
+          //         {
+          //           continue;
+          //         }
+          //       }
+          //     }
+          //   }
+          // }
+          else if (ApplyDRejection=="pas" && !DpassCut23PAS_) continue;
+          else if (ApplyDRejection=="lowpt" && !DpassCut23LowPt_) continue;
+          else if (ApplyDRejection=="passystdsvpv" && !DpassCut23PASSystDsvpv_) continue;
+          else if (ApplyDRejection=="passystdtrkpt" && !DpassCut23PASSystDtrkPt_) continue;
+        }
         countSelDzero++;
         MDzeroUPC.Dpt->push_back(MDzero.Dpt[iD]);
         MDzeroUPC.Dy->push_back(MDzero.Dy[iD]);
@@ -245,8 +346,10 @@ int main(int argc, char *argv[]) {
         MDzeroUPC.DsvpvDisErr_2D->push_back(MDzero.DsvpvDisErr_2D[iD]);
         MDzeroUPC.Dalpha->push_back(MDzero.Dalpha[iD]);
         MDzeroUPC.Ddtheta->push_back(MDzero.Ddtheta[iD]);
-        MDzeroUPC.DpassCut23PAS->push_back(DmesonSelectionPrelim23(MDzero,iD));
-        MDzeroUPC.DpassCut23LowPt->push_back(DmesonSelectionLowPt23(MDzero,iD));
+        MDzeroUPC.DpassCut23PAS->push_back(DpassCut23PAS_);
+        MDzeroUPC.DpassCut23LowPt->push_back(DpassCut23LowPt_);
+        MDzeroUPC.DpassCut23PASSystDsvpv->push_back(DpassCut23PASSystDsvpv_);
+        MDzeroUPC.DpassCut23PASSystDtrkPt->push_back(DpassCut23PASSystDtrkPt_);
         if (IsData == false) {
           MDzeroUPC.Dgen->push_back(MDzero.Dgen[iD]);
           bool isSignalGenMatched = MDzero.Dgen[iD] == 23333 && MDzero.Dgenpt[iD] > 0.;

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunExamples.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunExamples.sh
@@ -14,7 +14,7 @@ mkdir -p Output/
 #   --ApplyTriggerRejection 0 \
 #   --ApplyEventRejection false \
 #   --ApplyZDCGapRejection false \
-#   --ApplyDRejection 0 \
+#   --ApplyDRejection no \
 #   --ZDCMinus1nThreshold 1000 \
 #   --ZDCPlus1nThreshold 1100 \
 #   --PFTree particleFlowAnalyser/pftree
@@ -31,7 +31,7 @@ mkdir -p Output/
    --ApplyTriggerRejection 0 \
    --ApplyEventRejection true \
    --ApplyZDCGapRejection true \
-   --ApplyDRejection 1 \
+   --ApplyDRejection pas \
    --ZDCMinus1nThreshold 900 \
    --ZDCPlus1nThreshold 900 \
    --PFTree particleFlowAnalyser/pftree \
@@ -44,9 +44,10 @@ mkdir -p Output/
 #   --Output Output/output_44.root \
 #   --Year 2023 \
 #   --IsData false \
+#   --IsGammaN true \
 #   --ApplyTriggerRejection 0 \
 #   --ApplyEventRejection false \
 #   --ApplyZDCGapRejection false \
-#   --ApplyDRejection 0 \
+#   --ApplyDRejection no \
 #   --PFTree particleFlowAnalyser/pftree \
 #   --DGenTree Dfinder/ntGen

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunExamples.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunExamples.sh
@@ -44,7 +44,7 @@ mkdir -p Output/
 #   --Output Output/output_44.root \
 #   --Year 2023 \
 #   --IsData false \
-#   --IsGammaN true \
+#   --IsGammaNMCtype true \
 #   --ApplyTriggerRejection 0 \
 #   --ApplyEventRejection false \
 #   --ApplyZDCGapRejection false \

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunParallelData23.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunParallelData23.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 MAXCORES=100
 
-NAME="20241216_ForestDfinderData23LowPtSkim_v1"
+NAME="20250110_ForestDfinderData23LowPtSkim_v2"
 OUTPUT="output"
 counter=0
 filelist="/data00/UPCD0LowPtAnalysis_2023ZDCORData_2023reco/InputListForests/20241106_filelist_SkimOldReco23sample_DataAll.txt"
@@ -36,7 +36,7 @@ while IFS= read -r file; do
             --ApplyTriggerRejection 2 \
             --ApplyEventRejection true \
             --ApplyZDCGapRejection true \
-            --ApplyDRejection 2 \
+            --ApplyDRejection or \
             --ZDCMinus1nThreshold 1000 \
             --ZDCPlus1nThreshold 1100 \
             --IsData true \

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunParallelMC.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunParallelMC.sh
@@ -1,21 +1,25 @@
 #!/bin/bash
 MAXCORES=120
-SAMPLEID=4
+SAMPLEID=3
 
 echo "Running on sample ID: $SAMPLEID"
 
 if [ "$SAMPLEID" -eq 0 ]; then
-    NAMEMC="20241216_v1_filelist20241216_Pthat5_100Million_Inclusive_BeamAv1"
+    NAMEMC="20250110_v2_filelist20250110_Pthat5_100Million_Inclusive_BeamAv1"
     FOLDER="/data/UPCD0analysis_2023data_HIN24003/ForestsMC/OfficialMC_pTHat5/UnmergedForests/100Million_Inclusive_v1"
+    ISGAMMAN=true
 elif [ "$SAMPLEID" -eq 1 ]; then
-    NAMEMC="20241216_v1_filelist20241216_Pthat0_ForceD0Decay100M_BeamA_v1"
+    NAMEMC="20250110_v2_filelist20250110_Pthat0_ForceD0Decay100M_BeamA_v1"
     FOLDER="/data/UPCD0analysis_2023data_HIN24003/ForestsMC/OfficialMC_pTHat0/UnmergedForests/ForcedD0Decay100M_BeamA"
+    ISGAMMAN=true
 elif [ "$SAMPLEID" -eq 2 ]; then
-    NAMEMC="20241216_v1_filelist20241216_Pthat0_ForceD0Decay100M_BeamB_v1"
+    NAMEMC="20250110_v2_filelist20250110_Pthat0_ForceD0Decay100M_BeamB_v1"
     FOLDER="/data/UPCD0analysis_2023data_HIN24003/ForestsMC/OfficialMC_pTHat0/UnmergedForests/ForcedD0Decay100M_BeamB"
+    ISGAMMAN=false
 elif [ "$SAMPLEID" -eq 3 ]; then
-    NAMEMC="20241216_v1_filelist20241216_Pthat2_ForceD0Decay100M_BeamA_v1"
+    NAMEMC="20250110_v2_filelist20250110_Pthat2_ForceD0Decay100M_BeamA_v1"
     FOLDER="/data/UPCD0analysis_2023data_HIN24003/ForestsMC/OfficialMC_pTHat2/UnmergedForests/ForcedD0Decay100M_BeamA"
+    ISGAMMAN=true
 fi
 
 echo "Running on sample: $NAMEMC"
@@ -57,10 +61,11 @@ while IFS= read -r file; do
             --Output "$OUTPUTMC/output_$counterMC.root" \
             --Year 2023 \
             --IsData false \
+            --IsGammaN $ISGAMMAN \
             --ApplyTriggerRejection 0 \
             --ApplyEventRejection false \
             --ApplyZDCGapRejection false \
-            --ApplyDRejection 2 \
+            --ApplyDRejection no \
             --PFTree particleFlowAnalyser/pftree \
             --DGenTree Dfinder/ntGen &
     ((counterMC++))

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunParallelMC.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunParallelMC.sh
@@ -61,7 +61,7 @@ while IFS= read -r file; do
             --Output "$OUTPUTMC/output_$counterMC.root" \
             --Year 2023 \
             --IsData false \
-            --IsGammaN $ISGAMMAN \
+            --IsGammaNMCtype $ISGAMMAN \
             --ApplyTriggerRejection 0 \
             --ApplyEventRejection false \
             --ApplyZDCGapRejection false \

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/include/DmesonSelection.h
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/include/DmesonSelection.h
@@ -51,6 +51,115 @@ bool DmesonSelectionPrelim23(DzeroTreeMessenger &MDzero, int iD) {
 
   return pass;
 }
+
+bool DmesonSelectionPrelim23SystDsvpv(DzeroTreeMessenger &MDzero, int iD) {
+  const int nPtBinsOpt = 3;
+  const int nYBinsOpt = 4;
+
+  float Dchi2clCutValue[nPtBinsOpt][nYBinsOpt] = {{0.1, 0.1, 0.1, 0.1}, {0.1, 0.1, 0.1, 0.1}, {0.1, 0.1, 0.1, 0.1}};
+  float DalphaCutValue[nPtBinsOpt][nYBinsOpt] = {{0.2, 0.4, 0.4, 0.2}, {0.25, 0.35, 0.35, 0.25}, {0.25, 0.4, 0.4, 0.25}};
+  float DdthetaCutValue[nPtBinsOpt][nYBinsOpt] = {{0.3, 0.5, 0.5, 0.3}, {0.3, 0.3, 0.3, 0.3}, {0.3, 0.3, 0.3, 0.3}};
+  float DsvpvSigCutValue[nPtBinsOpt][nYBinsOpt] = {{2.0, 2.0, 2.0, 2.0}, {2.5, 2.5, 2.5, 2.5}, {2.5, 2.5, 2.5, 2.5}};
+  float Dtrk1PtCutValue[nPtBinsOpt][nYBinsOpt] = {{1.0, 1.0, 1.0, 1.0}, {1.0, 1.0, 1.0, 1.0}, {1.0, 1.0, 1.0, 1.0}};
+  float Dtrk2PtCutValue[nPtBinsOpt][nYBinsOpt] = {{1.0, 1.0, 1.0, 1.0}, {1.0, 1.0, 1.0, 1.0}, {1.0, 1.0, 1.0, 1.0}};
+
+  const int nPtBins = 3;
+  const int nYBins = 4;
+  float ptBins[nPtBins + 1] = {2, 5, 8, 12};
+  float yBins[nYBins + 1] = {-2.0, -1.0, 0.0, 1.0, 2.0};
+
+  float pt = MDzero.Dpt[iD];
+  float y = MDzero.Dy[iD];
+
+  // Determine pt and y bin indices
+  int ptBin = -1;
+  int yBin = -1;
+  for (int i = 0; i < nPtBins; ++i) {
+    if (pt >= ptBins[i] && pt < ptBins[i + 1]) {
+      ptBin = i;
+      break;
+    }
+  }
+  for (int j = 0; j < nYBins; ++j) {
+    if (y >= yBins[j] && y < yBins[j + 1]) {
+      yBin = j;
+      break;
+    }
+  }
+
+  // Check if the pt and y bins were found
+  if (ptBin == -1 || yBin == -1) {
+    // cerr << "Error! No pt bin and/or y bin found for D meson selection. "
+    //  << "pt = " << pt << ", y = " << y
+    //  << ". Please check if the pt or y values fall within the defined bin ranges." << endl;
+    return 0;
+  }
+
+  // Apply cuts for the identified ptBin and yBin
+  bool pass = (MDzero.Dtrk1Pt[iD] >= Dtrk1PtCutValue[ptBin][yBin]) &&
+              (MDzero.Dtrk2Pt[iD] >= Dtrk2PtCutValue[ptBin][yBin]) &&
+              (MDzero.Dchi2cl[iD] >= Dchi2clCutValue[ptBin][yBin]) &&
+              (MDzero.Dalpha[iD] <= DalphaCutValue[ptBin][yBin]) &&
+              (MDzero.Ddtheta[iD] <= DdthetaCutValue[ptBin][yBin]) &&
+              (MDzero.DsvpvDistance[iD] / MDzero.DsvpvDisErr[iD] >= DsvpvSigCutValue[ptBin][yBin]);
+
+  return pass;
+}
+
+bool DmesonSelectionPrelim23SystDtrkPt(DzeroTreeMessenger &MDzero, int iD) {
+  const int nPtBinsOpt = 3;
+  const int nYBinsOpt = 4;
+
+  float Dchi2clCutValue[nPtBinsOpt][nYBinsOpt] = {{0.1, 0.1, 0.1, 0.1}, {0.1, 0.1, 0.1, 0.1}, {0.1, 0.1, 0.1, 0.1}};
+  float DalphaCutValue[nPtBinsOpt][nYBinsOpt] = {{0.2, 0.4, 0.4, 0.2}, {0.25, 0.35, 0.35, 0.25}, {0.25, 0.4, 0.4, 0.25}};
+  float DdthetaCutValue[nPtBinsOpt][nYBinsOpt] = {{0.3, 0.5, 0.5, 0.3}, {0.3, 0.3, 0.3, 0.3}, {0.3, 0.3, 0.3, 0.3}};
+  float DsvpvSigCutValue[nPtBinsOpt][nYBinsOpt] = {{2.5, 2.5, 2.5, 2.5}, {3.5, 3.5, 3.5, 3.5}, {3.5, 3.5, 3.5, 3.5}};
+  float Dtrk1PtCutValue[nPtBinsOpt][nYBinsOpt] = {{0.7, 0.7, 0.7, 0.7}, {0.7, 0.7, 0.7, 0.7}, {0.7, 0.7, 0.7, 0.7}};
+  float Dtrk2PtCutValue[nPtBinsOpt][nYBinsOpt] = {{0.7, 0.7, 0.7, 0.7}, {0.7, 0.7, 0.7, 0.7}, {0.7, 0.7, 0.7, 0.7}};
+
+  const int nPtBins = 3;
+  const int nYBins = 4;
+  float ptBins[nPtBins + 1] = {2, 5, 8, 12};
+  float yBins[nYBins + 1] = {-2.0, -1.0, 0.0, 1.0, 2.0};
+
+  float pt = MDzero.Dpt[iD];
+  float y = MDzero.Dy[iD];
+
+  // Determine pt and y bin indices
+  int ptBin = -1;
+  int yBin = -1;
+  for (int i = 0; i < nPtBins; ++i) {
+    if (pt >= ptBins[i] && pt < ptBins[i + 1]) {
+      ptBin = i;
+      break;
+    }
+  }
+  for (int j = 0; j < nYBins; ++j) {
+    if (y >= yBins[j] && y < yBins[j + 1]) {
+      yBin = j;
+      break;
+    }
+  }
+
+  // Check if the pt and y bins were found
+  if (ptBin == -1 || yBin == -1) {
+    // cerr << "Error! No pt bin and/or y bin found for D meson selection. "
+    //  << "pt = " << pt << ", y = " << y
+    //  << ". Please check if the pt or y values fall within the defined bin ranges." << endl;
+    return 0;
+  }
+
+  // Apply cuts for the identified ptBin and yBin
+  bool pass = (MDzero.Dtrk1Pt[iD] >= Dtrk1PtCutValue[ptBin][yBin]) &&
+              (MDzero.Dtrk2Pt[iD] >= Dtrk2PtCutValue[ptBin][yBin]) &&
+              (MDzero.Dchi2cl[iD] >= Dchi2clCutValue[ptBin][yBin]) &&
+              (MDzero.Dalpha[iD] <= DalphaCutValue[ptBin][yBin]) &&
+              (MDzero.Ddtheta[iD] <= DdthetaCutValue[ptBin][yBin]) &&
+              (MDzero.DsvpvDistance[iD] / MDzero.DsvpvDisErr[iD] >= DsvpvSigCutValue[ptBin][yBin]);
+
+  return pass;
+}
+
 bool DmesonSelectionLowPt23(DzeroTreeMessenger &MDzero, int iD) {
   const int nPtBinsOpt = 4;
   const int nYBinsOpt = 4;

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/makefile
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/makefile
@@ -6,7 +6,7 @@ TestRun: Execute
                   --ApplyTriggerRejection 0 \
                   --ApplyEventRejection false \
                   --ApplyZDCGapRejection false \
-                  --ApplyDRejection 0 \
+                  --ApplyDRejection no \
                   --PFTree particleFlowAnalyser/pftree
 
 TestRunBase: Execute
@@ -15,10 +15,10 @@ TestRunBase: Execute
                   --ApplyTriggerRejection 0 \
                   --ApplyEventRejection false \
                   --ApplyZDCGapRejection false \
-                  --ApplyDRejection 0 \
+                  --ApplyDRejection no \
                   --PFTree particleFlowAnalyser/pftree
 
 Execute: ReduceForest.cpp
-	g++ ReduceForest.cpp -o Execute \
+	g++ -O3 ReduceForest.cpp -o Execute \
 		`root-config --cflags --glibs` \
 		-I$(ProjectBase)/CommonCode/include $(ProjectBase)/CommonCode/library/Messenger.o


### PR DESCRIPTION
### SampleGeneration
- [add] D selection systematics branches (`DpassCut23PASSystDsvpv`, `DpassCut23PASSystDtrkPt`)
- [new] MC event selections, gammaN/Ngamma tags ( gammaN: BeamA, Ngamma: BeamB )
- [mod] ApplyZDCGapRejection: filter at the loosest rapidity gap cut, ApplyDRejection: the default is to filter at the OR logic of all D cuts
- [mod] define the rapidity gap energy threshold array in the messenger
```cpp
   const std::vector<float> gapEThresh_gammaN = {4.3, 5.5, 6.4, 7.8, 9.2, 10.6, 12.5, 15.0, 16.2};
   const std::vector<float> gapEThresh_Ngamma = {4.5, 5.5, 6.5, 7.6, 8.6, 10.0, 12.0, 15.0, 16.0};
```
### MainAnalysis
- [add] for fit systematics study (`doSyst_sig`, `doSyst_comb`)
- [feature] for the mass fit add the option to do the systematics study on the signal modeling
- [tidy] only store the single fit config under pt-y-dir / fit dir /, and the entire setting is stored in the sample directory (named as fitconfig::xx.json)