### PR TITLE
Mass plot updates

### DIFF
--- a/MainAnalysis/20241210_DzeroUPC/massfit.C
+++ b/MainAnalysis/20241210_DzeroUPC/massfit.C
@@ -411,7 +411,8 @@ struct EventParams {
 
 void styleframe_massfit(RooPlot* frame)
 {
-  frame->SetYTitle("dN_{Event}/dM #times 1/dp_{T}dy [GeV^{-2}]");
+  float binWidth = (DMASSMAX - DMASSMIN) / DMASSNBINS;
+  frame->SetYTitle(Form("Events / (%.4f GeV)", binWidth));
   frame->SetTitleSize(0.045, "XY");
   frame->SetTitleOffset(0.85, "XY");
 }

--- a/MainAnalysis/20241210_DzeroUPC/massfit.C
+++ b/MainAnalysis/20241210_DzeroUPC/massfit.C
@@ -39,9 +39,9 @@ using namespace RooFit;
 
 using namespace std;
 
-#define DMASSMIN 1.68
-#define DMASSMAX 2.05
-#define DMASSNBINS 74
+#define DMASSMIN 1.67
+#define DMASSMAX 2.07
+#define DMASSNBINS 30
 
 struct ParamsBase {
   std::map<std::string, RooRealVar*> params; // Store RooRealVar objects
@@ -856,7 +856,7 @@ int main(int argc, char *argv[]) {
   // Construct the formatted string
   std::ostringstream plotTitle;
   plotTitle << parMinDzeroPT << " #leq D_{p_{T}} < " << parMaxDzeroPT
-            << " (GeV/#it{c}), " << parMinDzeroY << " #leq D_{y} < " << parMaxDzeroY
+            << " (GeV), " << parMinDzeroY << " #leq D_{y} < " << parMaxDzeroY
             << (parIsGammaN == 1 ? ", #gammaN" : ", N#gamma")
             << (parTriggerChoice == 1 ? ", ZDCOR" : ", ZDCXORJet8");
 

--- a/MainAnalysis/20241210_DzeroUPC/massfit.C
+++ b/MainAnalysis/20241210_DzeroUPC/massfit.C
@@ -769,6 +769,8 @@ void main_fit(TTree *datatree, string rstDir, string output,
   legend->AddEntry("combPDF","Combinatorics", "L");
   legend->Draw();
   
+  canvas->SaveAs(Form("%s/fit_result_full_legend.pdf", rstDir.c_str()));
+  
   TLatex latex;
   latex.SetTextSize(0.03);
   latex.SetNDC();
@@ -793,10 +795,12 @@ void main_fit(TTree *datatree, string rstDir, string output,
                                                     events.npkpp.getPropagatedError(*result)));
   latex.DrawLatex(xpos, ypos - (lineCount++) * ypos_step, Form("N_{Comb} = %.3f #pm %.3f", events.nbkg.getVal(), events.nbkg.getError()));
   
-  canvas->SaveAs(Form("%s/fit_result_full.pdf", rstDir.c_str()));
+  canvas->SaveAs(Form("%s/fit_result_full_param_legend.pdf", rstDir.c_str()));
   
   legend->Clear();
   canvas->Update();
+  
+  canvas->SaveAs(Form("%s/fit_result_full_param.pdf", rstDir.c_str()));
 
   double SoverB = events.nsig.getVal()/TMath::Sqrt(events.nsig.getVal()+events.nbkg.getVal());
 
@@ -825,7 +829,7 @@ void main_fit(TTree *datatree, string rstDir, string output,
   latex.DrawLatex(0.20, ypos - 1 * ypos_step, Form("p-value = %.3e", p_value));
   latex.DrawLatex(0.20, ypos - 2 * ypos_step, Form("Significance = %.1f#sigma", significance));
 
-  canvas->SaveAs(Form("%s/fit_result_full_sigsum.pdf", rstDir.c_str()));
+  canvas->SaveAs(Form("%s/fit_result_full_param_stats.pdf", rstDir.c_str()));
 
   delete canvas;
 }

--- a/MainAnalysis/20241210_DzeroUPC/plotCrossSection.C
+++ b/MainAnalysis/20241210_DzeroUPC/plotCrossSection.C
@@ -303,7 +303,7 @@ int main(int argc, char *argv[])
   // latex.DrawLatex(0.15, 0.92, "CMS #it{Preliminary} 1.38 nb^{-1} (5.36 TeV PbPb)");
   // latex.DrawLatex(0.15, 0.86, "UPCs, ZDC Xn0n w/ gap");
   // latex.DrawLatex(0.15, 0.82, "Global uncert. #pm 5.05%");
-  latex.DrawLatex(0.6, 0.82, Form("%d < D_{p_{T}} < %d (GeV/#it{c})", (int) MinDzeroPT, (int) MaxDzeroPT));
+  latex.DrawLatex(0.6, 0.82, Form("%d < D_{p_{T}} < %d (GeV)", (int) MinDzeroPT, (int) MaxDzeroPT));
 
   c1->Update();
   c1->SaveAs(Form("%s/correctedYieldValuesPlot_pt%d-%d_IsGammaN%o.pdf",
@@ -334,7 +334,7 @@ int main(int argc, char *argv[])
   gr2->SetLineWidth(2);
   gr2->Draw("P E1 SAME");
 
-  latex.DrawLatex(0.6, 0.82, Form("%d < D_{p_{T}} < %d (GeV/#it{c})", (int) MinDzeroPT, (int) MaxDzeroPT));
+  latex.DrawLatex(0.6, 0.82, Form("%d < D_{p_{T}} < %d (GeV)", (int) MinDzeroPT, (int) MaxDzeroPT));
 
   c1->Update();
   c1->SaveAs(Form("%s/RFBPlot_pt%d-%d_IsGammaN%o.pdf",

--- a/MainAnalysis/20241210_DzeroUPC/plotCrossSection.C
+++ b/MainAnalysis/20241210_DzeroUPC/plotCrossSection.C
@@ -303,7 +303,7 @@ int main(int argc, char *argv[])
   // latex.DrawLatex(0.15, 0.92, "CMS #it{Preliminary} 1.38 nb^{-1} (5.36 TeV PbPb)");
   // latex.DrawLatex(0.15, 0.86, "UPCs, ZDC Xn0n w/ gap");
   // latex.DrawLatex(0.15, 0.82, "Global uncert. #pm 5.05%");
-  latex.DrawLatex(0.6, 0.82, Form("%d < D_{p_{T}} < %d (GeVx`)", (int) MinDzeroPT, (int) MaxDzeroPT));
+  latex.DrawLatex(0.6, 0.82, Form("%d < D_{p_{T}} < %d (GeV)", (int) MinDzeroPT, (int) MaxDzeroPT));
 
   c1->Update();
   c1->SaveAs(Form("%s/correctedYieldValuesPlot_pt%d-%d_IsGammaN%o.pdf",

--- a/MainAnalysis/20241210_DzeroUPC/plotCrossSection.C
+++ b/MainAnalysis/20241210_DzeroUPC/plotCrossSection.C
@@ -303,7 +303,7 @@ int main(int argc, char *argv[])
   // latex.DrawLatex(0.15, 0.92, "CMS #it{Preliminary} 1.38 nb^{-1} (5.36 TeV PbPb)");
   // latex.DrawLatex(0.15, 0.86, "UPCs, ZDC Xn0n w/ gap");
   // latex.DrawLatex(0.15, 0.82, "Global uncert. #pm 5.05%");
-  latex.DrawLatex(0.6, 0.82, Form("%d < D_{p_{T}} < %d (GeV)", (int) MinDzeroPT, (int) MaxDzeroPT));
+  latex.DrawLatex(0.6, 0.82, Form("%d < D_{p_{T}} < %d (GeVx`)", (int) MinDzeroPT, (int) MaxDzeroPT));
 
   c1->Update();
   c1->SaveAs(Form("%s/correctedYieldValuesPlot_pt%d-%d_IsGammaN%o.pdf",


### PR DESCRIPTION
Updates to mass fit plots and related plots, based on feedback. Summary of changes below:
- Rebinned massfits to 32 bins
- Changed "GeV/c" to "GeV" per feedback
- Increased axes title sizes per feedback
- Full massfit plot is saved in three versions:
    - Plot with stats
    - Plot with legend and fit-setting stats
    - Plot without stats or legend