### PR TITLE
Reduce max cores to 40

### DIFF
--- a/SampleGeneration/20241025_ForestReducer_MuMuJet/RunParallelData.sh
+++ b/SampleGeneration/20241025_ForestReducer_MuMuJet/RunParallelData.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-MAXCORES=120
+MAXCORES=40
 
 NAME="SkimData2018PbPb_Version20241201_v4_ForestVersion_20241023_v220241023_v2"
 OUTPUT="output"

--- a/SampleGeneration/20241025_ForestReducer_MuMuJet/RunParallelMC.sh
+++ b/SampleGeneration/20241025_ForestReducer_MuMuJet/RunParallelMC.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-MAXCORES=120
+MAXCORES=40
 
 NAME="SkimMC2018PbPb_Version20241201_InputForest_20241201_DiJet_pThat-15_TuneCP5_HydjetDrumMB_5p02TeV_Pythia8_PARTIAL"
 OUTPUT="output"

--- a/SampleGeneration/20241027_ForestReducer_DzeroUPC/RunParallelData.sh
+++ b/SampleGeneration/20241027_ForestReducer_DzeroUPC/RunParallelData.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-MAXCORES=120
+MAXCORES=40
 
 NAME="2024117_ForestDfinderData"
 OUTPUT="output"

--- a/SampleGeneration/20241027_ForestReducer_DzeroUPC/RunParallelMC.sh
+++ b/SampleGeneration/20241027_ForestReducer_DzeroUPC/RunParallelMC.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-MAXCORES=100
+MAXCORES=40
 
 NAMEMC="XYZ_filelist_SkimOldReco23sample_MCPthat2"
 OUTPUTMC="outputMC"

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunParallelData23.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunParallelData23.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-MAXCORES=100
+MAXCORES=40
 
 NAME="20250117_ForestDfinderData23Skim_v3"
 OUTPUT="output"

--- a/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunParallelMC.sh
+++ b/SampleGeneration/20241214_ForestReducer_DzeroUPC_2023OldReco/RunParallelMC.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-MAXCORES=120
+MAXCORES=40
 SAMPLEID=0
 
 echo "Running on sample ID: $SAMPLEID"

--- a/SampleGeneration/20241220_ForestReducer_MuMuJet/RunParallelData.sh
+++ b/SampleGeneration/20241220_ForestReducer_MuMuJet/RunParallelData.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-MAXCORES=120
+MAXCORES=40
 
 NAME="SkimData2018PbPb_Version20241201_v4_ForestVersion_20241023_v220241023_v2"
 OUTPUT="output"

--- a/SampleGeneration/20241220_ForestReducer_MuMuJet/RunParallelMC.sh
+++ b/SampleGeneration/20241220_ForestReducer_MuMuJet/RunParallelMC.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-MAXCORES=120
+MAXCORES=40
 SAMPLEID=0
 
 echo "Running on sample ID: $SAMPLEID"

--- a/SampleGeneration/20250121_ForestReducer_DzeroUPC_2023NewReco/RunParallelData23.sh
+++ b/SampleGeneration/20250121_ForestReducer_DzeroUPC_2023NewReco/RunParallelData23.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-MAXCORES=100
+MAXCORES=40
 
 NAME="20241216_ForestDfinderData23LowPtSkim_v1"
 OUTPUT="output"

--- a/SampleGeneration/20250121_ForestReducer_DzeroUPC_2023NewReco/RunParallelMC.sh
+++ b/SampleGeneration/20250121_ForestReducer_DzeroUPC_2023NewReco/RunParallelMC.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-MAXCORES=120
+MAXCORES=40
 SAMPLEID=4
 
 echo "Running on sample ID: $SAMPLEID"


### PR DESCRIPTION
Reduces max number of cores for all `RunParallel*.sh` scripts under SampleGeneration to a default of 40 (down from 100 and 120). Previous settings were semi-regularly leading to server problems for all users if the previous settings were not changed first.