### PR TITLE
Updates to main analysis code

### DIFF
--- a/MainAnalysis/20250804_ChargedHadrondNdpt/ChargedHadrondNdpT.cpp
+++ b/MainAnalysis/20250804_ChargedHadrondNdpt/ChargedHadrondNdpT.cpp
@@ -35,6 +35,19 @@ const Double_t pTBins_log[nPtBins_log + 1] = {
 
 bool checkError(const Parameters &par) { return false; }
 
+void NormalizeByBinWidth(TH1* hist) {
+    for (int i = 1; i <= hist->GetNbinsX(); ++i) {
+        double binContent = hist->GetBinContent(i);
+        double binError   = hist->GetBinError(i);
+        double binWidth   = hist->GetBinWidth(i);
+
+        // Normalize
+        hist->SetBinContent(i, binContent / binWidth);
+        hist->SetBinError(i, binError / binWidth);
+    }
+}
+
+
 //============================================================//
 // Data analyzer class
 //============================================================//
@@ -171,6 +184,16 @@ public:
 
   void writeHistograms(TFile *outf) {
     outf->cd();
+
+    NormalizeByBinWidth(hTrkPtNoEvt);
+    NormalizeByBinWidth(hTrkPtNoTrk);
+    NormalizeByBinWidth(hTrkPtNoPartSpecies);
+    NormalizeByBinWidth(hTrkPt);
+    NormalizeByBinWidth(hTrkPtUnweighted);
+    NormalizeByBinWidth(hTrkEta);
+    NormalizeByBinWidth(hTrkEtaUnweighted);
+
+
     smartWrite(hTrkPtNoEvt);
     smartWrite(hTrkPtNoTrk);
     smartWrite(hTrkPtNoPartSpecies);


### PR DESCRIPTION
This update incorporates two main things:

-pT bin width normalization in output files.

-track selection has been updated (before, we were cutting on the weight to reject tracks that do not pass the track selection requirement, now we just explicitly reject them with an if statement).